### PR TITLE
t/13: Ctrl+A in a nested editable should select nested editable's content

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -127,14 +127,19 @@ export default class Widget extends Plugin {
 	_onKeydown( eventInfo, domEventData ) {
 		const keyCode = domEventData.keyCode;
 		const isForward = keyCode == keyCodes.delete || keyCode == keyCodes.arrowdown || keyCode == keyCodes.arrowright;
+		let wasHandled = false;
 
 		// Checks if the keys were handled and then prevents the default event behaviour and stops
 		// the propagation.
-		if (
-			( isDeleteKeyCode( keyCode ) && this._handleDelete( isForward ) ) ||
-			( isArrowKeyCode( keyCode ) && this._handleArrowKeys( isForward ) ) ||
-			( isSelectAllKeyCode( domEventData ) && this._selectAllNestedEditableContent() )
-		) {
+		if ( isDeleteKeyCode( keyCode ) ) {
+			wasHandled = this._handleDelete( isForward );
+		} else if ( isArrowKeyCode( keyCode ) ) {
+			wasHandled = this._handleArrowKeys( isForward );
+		} else if ( isSelectAllKeyCode( domEventData ) ) {
+			wasHandled = this._selectAllNestedEditableContent();
+		}
+
+		if ( wasHandled ) {
 			domEventData.preventDefault();
 			eventInfo.stop();
 		}

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -34,6 +34,7 @@ describe( 'Widget', () => {
 				doc.schema.registerItem( 'inline', '$inline' );
 				doc.schema.objects.add( 'inline' );
 				doc.schema.registerItem( 'nested' );
+				doc.schema.limits.add( 'nested' );
 				doc.schema.allow( { name: '$inline', inside: 'nested' } );
 				doc.schema.allow( { name: 'nested', inside: 'widget' } );
 				doc.schema.registerItem( 'editable' );
@@ -741,6 +742,22 @@ describe( 'Widget', () => {
 				'<paragraph>[foo]</paragraph><widget></widget><paragraph>[bar]</paragraph>',
 				keyCodes.arrowright,
 				'<paragraph>[foo]</paragraph><widget></widget><paragraph>[bar]</paragraph>'
+			);
+		} );
+
+		describe( 'Ctrl+A', () => {
+			test(
+				'should select the entire content of the nested editable',
+				'<widget><nested>foo[]</nested></widget><paragraph>bar</paragraph>',
+				{ keyCode: keyCodes.a, ctrlKey: true },
+				'<widget><nested>[foo]</nested></widget><paragraph>bar</paragraph>'
+			);
+
+			test(
+				'should not change the selection if outside of the nested editable',
+				'<widget><nested>foo</nested></widget><paragraph>[]bar</paragraph>',
+				{ keyCode: keyCodes.a, ctrlKey: true },
+				'<widget><nested>foo</nested></widget><paragraph>[]bar</paragraph>'
 			);
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Ctrl+A in a nested editable should select nested editable's content. Closes #13.

---

### Additional information

Also closes https://github.com/ckeditor/ckeditor5-image/issues/55.
