### PR TITLE
T/19: Remove the entire empty element if it is next to a widget

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -165,12 +165,15 @@ export default class Widget extends Plugin {
 
 		if ( objectElement ) {
 			modelDocument.enqueueChanges( () => {
-				// Remove previous element if empty.
-				const previousNode = modelSelection.anchor.parent;
+				const batch = modelDocument.batch();
+				let previousNode = modelSelection.anchor.parent;
 
-				if ( previousNode.isEmpty ) {
-					const batch = modelDocument.batch();
-					batch.remove( previousNode );
+				// Remove previous element if empty.
+				while ( previousNode.isEmpty ) {
+					const nodeToRemove = previousNode;
+					previousNode = nodeToRemove.parent;
+
+					batch.remove( nodeToRemove );
 				}
 
 				this._setSelectionOverElement( objectElement );

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -508,6 +508,21 @@ describe( 'Widget', () => {
 			);
 
 			test(
+				'should remove the entire empty element (deeper structure) if it is next to a widget (forward delete)',
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote><div><div><paragraph>[]</paragraph></div></div></blockQuote>' +
+				'<image></image>' +
+				'<paragraph>foo</paragraph>',
+
+				keyCodes.delete,
+
+				'<paragraph>foo</paragraph>' +
+				'[<image></image>]' +
+				'<paragraph>foo</paragraph>'
+			);
+
+			test(
 				'should not remove the entire element which is not empty and the element is next to a widget',
 
 				'<paragraph>foo</paragraph>' +
@@ -520,6 +535,22 @@ describe( 'Widget', () => {
 				'<paragraph>foo</paragraph>' +
 				'[<image></image>]' +
 				'<blockQuote><paragraph></paragraph></blockQuote>' +
+				'<paragraph>foo</paragraph>'
+			);
+
+			test(
+				'should not remove the entire element which is not empty and the element is next to a widget (forward delete)',
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote><paragraph>Foo</paragraph><paragraph>[]</paragraph></blockQuote>' +
+				'<image></image>' +
+				'<paragraph>foo</paragraph>',
+
+				keyCodes.delete,
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote><paragraph>Foo</paragraph></blockQuote>' +
+				'[<image></image>]' +
 				'<paragraph>foo</paragraph>'
 			);
 

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -955,6 +955,62 @@ describe( 'Widget', () => {
 				'</blockQuote>' +
 				'<paragraph>foo</paragraph>'
 			);
+
+			test(
+				'should work if selection is in nested element (right arrow)',
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote>' +
+					'<div>' +
+						'<div>' +
+							'<paragraph>[]</paragraph>' +
+						'</div>' +
+					'</div>' +
+				'</blockQuote>' +
+				'<image></image>' +
+				'<paragraph>foo</paragraph>',
+
+				keyCodes.arrowright,
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote>' +
+					'<div>' +
+						'<div>' +
+							'<paragraph></paragraph>' +
+						'</div>' +
+					'</div>' +
+				'</blockQuote>' +
+				'[<image></image>]' +
+				'<paragraph>foo</paragraph>'
+			);
+
+			test(
+				'should work if selection is in nested element (down arrow)',
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote>' +
+					'<div>' +
+						'<div>' +
+							'<paragraph>[]</paragraph>' +
+						'</div>' +
+					'</div>' +
+				'</blockQuote>' +
+				'<image></image>' +
+				'<paragraph>foo</paragraph>',
+
+				keyCodes.arrowdown,
+
+				'<paragraph>foo</paragraph>' +
+				'<blockQuote>' +
+					'<div>' +
+						'<div>' +
+							'<paragraph></paragraph>' +
+						'</div>' +
+					'</div>' +
+				'</blockQuote>' +
+				'[<image></image>]' +
+				'<paragraph>foo</paragraph>'
+			);
 		} );
 
 		describe( 'Ctrl+A', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Nested element structures next to widgets will be correctly removed when pressing <kbd>Backspace</kbd> or <kbd>Delete</kbd>. Closes #19.

---

### Additional information

Bug reported in https://github.com/ckeditor/ckeditor5/issues/532 cannot be reproduced anymore with this fix.
