### PR TITLE
Changed how removeHighlight is handled according do changes in engine.

### DIFF
--- a/src/highlightstack.js
+++ b/src/highlightstack.js
@@ -54,13 +54,13 @@ export default class HighlightStack {
 	 * Removes highlight descriptor from the stack.
 	 *
 	 * @fires change:top
-	 * @param {module:engine/conversion/model-to-view-converters~HighlightDescriptor} descriptor
+	 * @param {String} id Id of the descriptor to remove.
 	 */
-	remove( descriptor ) {
+	remove( id ) {
 		const stack = this._stack;
 
 		const oldTop = stack[ 0 ];
-		this._removeDescriptor( descriptor );
+		this._removeDescriptor( id );
 		const newTop = stack[ 0 ];
 
 		// When new object is at the top and stores different information.
@@ -108,11 +108,11 @@ export default class HighlightStack {
 	 * Removes descriptor with given id from the stack.
 	 *
 	 * @private
-	 * @param {module:engine/conversion/model-to-view-converters~HighlightDescriptor} descriptor
+	 * @param {String} id Descriptor's id.
 	 */
-	_removeDescriptor( descriptor ) {
+	_removeDescriptor( id ) {
 		const stack = this._stack;
-		const index = stack.findIndex( item => item.id === descriptor.id );
+		const index = stack.findIndex( item => item.id === id );
 
 		// If descriptor with same id is on the list - remove it.
 		if ( index > -1 ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ export function setHighlightHandling( element, add, remove ) {
 	} );
 
 	element.setCustomProperty( 'addHighlight', ( element, descriptor ) => stack.add( descriptor ) );
-	element.setCustomProperty( 'removeHighlight', ( element, descriptor ) => stack.remove( descriptor ) );
+	element.setCustomProperty( 'removeHighlight', ( element, id ) => stack.remove( id ) );
 }
 
 /**

--- a/tests/highlightstack.js
+++ b/tests/highlightstack.js
@@ -79,7 +79,7 @@ describe( 'HighlightStack', () => {
 
 		stack.on( 'change:top', spy );
 
-		stack.remove( secondDescriptor );
+		stack.remove( secondDescriptor.id );
 
 		sinon.assert.calledOnce( spy );
 		expect( spy.firstCall.args[ 1 ].oldDescriptor ).to.equal( secondDescriptor );
@@ -143,7 +143,7 @@ describe( 'HighlightStack', () => {
 
 		stack.add( descriptor );
 		stack.on( 'change:top', spy );
-		stack.remove( descriptor );
+		stack.remove( descriptor.id );
 
 		sinon.assert.calledOnce( spy );
 		expect( spy.firstCall.args[ 1 ].newDescriptor ).to.be.undefined;
@@ -158,7 +158,7 @@ describe( 'HighlightStack', () => {
 		stack.add( descriptor );
 		stack.add( secondDescriptor );
 		stack.on( 'change:top', spy );
-		stack.remove( secondDescriptor );
+		stack.remove( secondDescriptor.id );
 
 		sinon.assert.notCalled( spy );
 	} );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -62,7 +62,7 @@ describe( 'widget utils', () => {
 			set( element, { priority: 1, class: 'highlight', id: 'highlight' } );
 			expect( element.hasClass( 'highlight' ) ).to.be.true;
 
-			remove( element, { priority: 1, class: 'highlight', id: 'highlight' } );
+			remove( element, 'highlight' );
 			expect( element.hasClass( 'highlight' ) ).to.be.false;
 		} );
 
@@ -79,7 +79,7 @@ describe( 'widget utils', () => {
 			expect( element.hasClass( 'highlight' ) ).to.be.true;
 			expect( element.hasClass( 'foo' ) ).to.be.true;
 
-			remove( element, { priority: 1, class: [ 'foo', 'highlight' ], id: 'highlight' } );
+			remove( element, 'highlight' );
 			expect( element.hasClass( 'highlight' ) ).to.be.false;
 			expect( element.hasClass( 'foo' ) ).to.be.false;
 		} );
@@ -177,7 +177,7 @@ describe( 'widget utils', () => {
 			const descriptor = { priority: 10, class: 'highlight', id: 'highlight' };
 
 			set( element, descriptor );
-			remove( element, descriptor );
+			remove( element, descriptor.id );
 
 			sinon.assert.calledOnce( addSpy );
 			sinon.assert.calledWithExactly( addSpy, element, descriptor );
@@ -215,7 +215,7 @@ describe( 'widget utils', () => {
 
 			set( element, descriptor );
 			set( element, secondDescriptor );
-			remove( element, secondDescriptor );
+			remove( element, secondDescriptor.id );
 
 			sinon.assert.calledThrice( addSpy );
 			expect( addSpy.firstCall.args[ 1 ] ).to.equal( descriptor );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Widgets highlight remove handler will now use only descriptor id, instead of the full descriptor.

BREAKING CHANGE: `HighlightStack.remove` method uses highlight id instead of `HighlightDescriptor`.