### PR TITLE
Fixed setting contenteditable attribute to string instead of boolean.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ export function isWidget( element ) {
 
 /**
  * Converts given {@link module:engine/view/element~Element} to widget in following way:
- * * sets `contenteditable` attribute to `true`,
+ * * sets `contenteditable` attribute to `"true"`,
  * * adds custom `getFillerOffset` method returning `null`,
  * * adds `ck-widget` CSS class,
  * * adds custom property allowing to recognize widget elements by using {@link ~isWidget},
@@ -51,7 +51,7 @@ export function isWidget( element ) {
  * @returns {module:engine/view/element~Element} Returns same element.
  */
 export function toWidget( element, options = {} ) {
-	element.setAttribute( 'contenteditable', false );
+	element.setAttribute( 'contenteditable', 'false' );
 	element.getFillerOffset = getFillerOffset;
 	element.addClass( WIDGET_CLASS_NAME );
 	element.setCustomProperty( widgetSymbol, true );
@@ -141,11 +141,11 @@ export function toWidgetEditable( editable ) {
 	editable.addClass( 'ck-editable' );
 
 	// Set initial contenteditable value.
-	editable.setAttribute( 'contenteditable', !editable.isReadOnly );
+	editable.setAttribute( 'contenteditable', editable.isReadOnly ? 'false' : 'true' );
 
 	// Bind contenteditable property to element#isReadOnly.
 	editable.on( 'change:isReadOnly', ( evt, property, is ) => {
-		editable.setAttribute( 'contenteditable', !is );
+		editable.setAttribute( 'contenteditable', is ? 'false' : 'true' );
 	} );
 
 	editable.on( 'change:isFocused', ( evt, property, is ) => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -25,8 +25,8 @@ describe( 'widget utils', () => {
 	} );
 
 	describe( 'toWidget()', () => {
-		it( 'should set contenteditable to false', () => {
-			expect( element.getAttribute( 'contenteditable' ) ).to.be.false;
+		it( 'should set contenteditable to "false"', () => {
+			expect( element.getAttribute( 'contenteditable' ) ).to.equal( 'false' );
 		} );
 
 		it( 'should define getFillerOffset method', () => {
@@ -138,12 +138,21 @@ describe( 'widget utils', () => {
 			expect( element.hasClass( 'ck-editable' ) ).to.be.true;
 		} );
 
-		it( 'should add proper contenteditable value when element is read-only', () => {
-			element.isReadOnly = false;
-			expect( element.getAttribute( 'contenteditable' ) ).to.true;
-
+		it( 'should add proper contenteditable value when element is read-only - initialization', () => {
+			const element = new ViewEditableElement( 'div' );
+			element.document = viewDocument;
 			element.isReadOnly = true;
-			expect( element.getAttribute( 'contenteditable' ) ).to.false;
+			toWidgetEditable( element );
+
+			expect( element.getAttribute( 'contenteditable' ) ).to.equal( 'false' );
+		} );
+
+		it( 'should add proper contenteditable value when element is read-only - when changing', () => {
+			element.isReadOnly = true;
+			expect( element.getAttribute( 'contenteditable' ) ).to.equal( 'false' );
+
+			element.isReadOnly = false;
+			expect( element.getAttribute( 'contenteditable' ) ).to.equal( 'true' );
 		} );
 
 		it( 'should add proper class when element is focused', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Using strings instead of boolean values in contenteditable attribute. Closes #26.

