### PR TITLE
.ck class should not be added to elements inside editor editable

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -53,7 +53,7 @@ export function isWidget( element ) {
  */
 export function toWidget( element, writer, options = {} ) {
 	writer.setAttribute( 'contenteditable', 'false', element );
-	writer.addClass( [ 'ck', WIDGET_CLASS_NAME ], element );
+	writer.addClass( WIDGET_CLASS_NAME, element );
 	writer.setCustomProperty( widgetSymbol, true, element );
 	element.getFillerOffset = getFillerOffset;
 
@@ -143,7 +143,7 @@ export function getLabel( element ) {
  * @returns {module:engine/view/editableelement~EditableElement} Returns same element that was provided in `editable` param.
  */
 export function toWidgetEditable( editable, writer ) {
-	writer.addClass( [ 'ck', 'ck-editor__editable', 'ck-editor__nested-editable' ], editable );
+	writer.addClass( [ 'ck-editor__editable', 'ck-editor__nested-editable' ], editable );
 
 	// Set initial contenteditable value.
 	writer.setAttribute( 'contenteditable', editable.isReadOnly ? 'false' : 'true', editable );

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -139,7 +139,7 @@ describe( 'widget utils', () => {
 		} );
 
 		it( 'should add proper class', () => {
-			expect( element.hasClass( 'ck', 'ck-editor__editable', 'ck-editor__nested-editable' ) ).to.be.true;
+			expect( element.hasClass( 'ck-editor__editable', 'ck-editor__nested-editable' ) ).to.be.true;
 		} );
 
 		it( 'should add proper contenteditable value when element is read-only - initialization', () => {

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -184,7 +184,7 @@ describe( 'Widget', () => {
 		setModelData( model, '[<widget>foo bar</widget>]' );
 
 		expect( getViewData( view ) ).to.equal(
-			'[<div class="ck ck-widget ck-widget_selected" contenteditable="false">foo bar<b></b></div>]'
+			'[<div class="ck-widget ck-widget_selected" contenteditable="false">foo bar<b></b></div>]'
 		);
 		expect( viewDocument.selection.isFake ).to.be.true;
 	} );
@@ -202,8 +202,8 @@ describe( 'Widget', () => {
 		expect( getViewData( view ) ).to.equal(
 			'[' +
 			'<p>foo</p>' +
-			'<div class="ck ck-widget ck-widget_selected" contenteditable="false"><b></b></div>' +
-			'<div class="ck ck-widget ck-widget_selected" contenteditable="false"><b></b></div>' +
+			'<div class="ck-widget ck-widget_selected" contenteditable="false"><b></b></div>' +
+			'<div class="ck-widget ck-widget_selected" contenteditable="false"><b></b></div>' +
 			']'
 		);
 	} );
@@ -218,7 +218,7 @@ describe( 'Widget', () => {
 		setModelData( model, '<paragraph>foo</paragraph>[<widget>foo</widget>]' );
 
 		expect( getViewData( view ) ).to.equal(
-			'<p>foo</p>[<div class="ck ck-widget ck-widget_selected" contenteditable="false">foo<b></b></div>]'
+			'<p>foo</p>[<div class="ck-widget ck-widget_selected" contenteditable="false">foo<b></b></div>]'
 		);
 
 		model.change( writer => {
@@ -226,7 +226,7 @@ describe( 'Widget', () => {
 		} );
 
 		expect( getViewData( view ) ).to.equal(
-			'<p>{}foo</p><div class="ck ck-widget" contenteditable="false">foo<b></b></div>'
+			'<p>{}foo</p><div class="ck-widget" contenteditable="false">foo<b></b></div>'
 		);
 	} );
 
@@ -234,7 +234,7 @@ describe( 'Widget', () => {
 		setModelData( model, '<widget><editable>foo bar</editable></widget><editable>[baz]</editable>' );
 
 		expect( getViewData( view ) ).to.equal(
-			'<div class="ck ck-widget" contenteditable="false">' +
+			'<div class="ck-widget" contenteditable="false">' +
 				'<figcaption contenteditable="true">foo bar</figcaption>' +
 				'<b></b>' +
 			'</div>' +
@@ -676,7 +676,7 @@ describe( 'Widget', () => {
 				'<paragraph>foo</paragraph>[<widget></widget>]<paragraph>bar</paragraph>',
 				{ keyCode: keyCodes.a, ctrlKey: true },
 				'[<paragraph>foo</paragraph><widget></widget><paragraph>bar</paragraph>]',
-				'[<p>foo</p><div class="ck ck-widget ck-widget_selected" contenteditable="false"><b></b></div><p>bar</p>]'
+				'[<p>foo</p><div class="ck-widget ck-widget_selected" contenteditable="false"><b></b></div><p>bar</p>]'
 
 			);
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `.ck` class should not be added to elements inside editor editable.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/936