### PR TITLE
Remove Position, Range, Selection imports from engine/model.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^11.0.1",
     "@ckeditor/ckeditor5-engine": "^11.0.0",
-    "@ckeditor/ckeditor5-utils": "^11.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^11.1.0",
-    "@ckeditor/ckeditor5-ui": "^11.1.0"
+    "@ckeditor/ckeditor5-ui": "^11.1.0",
+    "@ckeditor/ckeditor5-utils": "^11.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^10.0.3",

--- a/src/utils.js
+++ b/src/utils.js
@@ -269,7 +269,7 @@ export function findOptimalInsertionPosition( selection ) {
 		// If inserting into an empty block – return position in that block. It will get
 		// replaced with the image by insertContent(). #42.
 		if ( firstBlock.isEmpty ) {
-			return ModelPosition.createAt( firstBlock );
+			return ModelPosition.createAt( firstBlock, 0 );
 		}
 
 		const positionAfter = ModelPosition.createAfter( firstBlock );
@@ -314,6 +314,6 @@ function addSelectionHandler( editable, writer ) {
 	} );
 
 	// Append the selection handler into the widget wrapper.
-	writer.insert( ViewPosition.createAt( editable ), selectionHandler );
+	writer.insert( ViewPosition.createAt( editable, 0 ), selectionHandler );
 	writer.addClass( [ 'ck-widget_selectable' ], editable );
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,6 @@
  */
 
 import HighlightStack from './highlightstack';
-import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
 import IconView from '@ckeditor/ckeditor5-ui/src/icon/iconview';
 import env from '@ckeditor/ckeditor5-utils/src/env';
 
@@ -314,6 +313,6 @@ function addSelectionHandler( editable, writer ) {
 	} );
 
 	// Append the selection handler into the widget wrapper.
-	writer.insert( ViewPosition.createAt( editable, 0 ), selectionHandler );
+	writer.insert( writer.createPositionAt( editable, 0 ), selectionHandler );
 	writer.addClass( [ 'ck-widget_selectable' ], editable );
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,6 @@
 
 import HighlightStack from './highlightstack';
 import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
-import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
 import IconView from '@ckeditor/ckeditor5-ui/src/icon/iconview';
 import env from '@ckeditor/ckeditor5-utils/src/env';
 
@@ -254,13 +253,14 @@ export function toWidgetEditable( editable, writer ) {
  *
  * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
  * The selection based on which the insertion position should be calculated.
+ * @param {module:engine/model/model~Model} model Model instance.
  * @returns {module:engine/model/position~Position} The optimal position.
  */
-export function findOptimalInsertionPosition( selection ) {
+export function findOptimalInsertionPosition( selection, model ) {
 	const selectedElement = selection.getSelectedElement();
 
 	if ( selectedElement ) {
-		return ModelPosition.createAfter( selectedElement );
+		return model.createPositionAfter( selectedElement );
 	}
 
 	const firstBlock = selection.getSelectedBlocks().next().value;
@@ -269,10 +269,10 @@ export function findOptimalInsertionPosition( selection ) {
 		// If inserting into an empty block – return position in that block. It will get
 		// replaced with the image by insertContent(). #42.
 		if ( firstBlock.isEmpty ) {
-			return ModelPosition.createAt( firstBlock, 0 );
+			return model.createPositionAt( firstBlock, 0 );
 		}
 
-		const positionAfter = ModelPosition.createAfter( firstBlock );
+		const positionAfter = model.createPositionAfter( firstBlock );
 
 		// If selection is at the end of the block - return position after the block.
 		if ( selection.focus.isTouching( positionAfter ) ) {
@@ -280,7 +280,7 @@ export function findOptimalInsertionPosition( selection ) {
 		}
 
 		// Otherwise return position before the block.
-		return ModelPosition.createBefore( firstBlock );
+		return model.createPositionBefore( firstBlock );
 	}
 
 	return selection.focus;

--- a/src/widget.js
+++ b/src/widget.js
@@ -9,9 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import MouseObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mouseobserver';
-import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
-import ModelSelection from '@ckeditor/ckeditor5-engine/src/model/selection';
-import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
 import RootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditableelement';
 import { isWidget, WIDGET_SELECTED_CLASS_NAME, getLabel } from './utils';
@@ -248,7 +245,7 @@ export default class Widget extends Plugin {
 
 		const objectElement2 = this._getObjectElementNextToSelection( isForward );
 
-		if ( objectElement2 instanceof ModelElement && schema.isObject( objectElement2 ) ) {
+		if ( !!objectElement2 && schema.isObject( objectElement2 ) ) {
 			this._setSelectionOverElement( objectElement2 );
 
 			return true;
@@ -301,7 +298,7 @@ export default class Widget extends Plugin {
 		}
 
 		model.change( writer => {
-			writer.setSelection( ModelRange.createIn( limitElement ) );
+			writer.setSelection( writer.createRangeIn( limitElement ) );
 		} );
 
 		return true;
@@ -328,7 +325,7 @@ export default class Widget extends Plugin {
 			const widgetParent = editing.mapper.toModelElement( selectedElement.parent );
 
 			model.change( writer => {
-				writer.setSelection( ModelRange.createIn( widgetParent ) );
+				writer.setSelection( writer.createRangeIn( widgetParent ) );
 			} );
 
 			return true;
@@ -345,7 +342,7 @@ export default class Widget extends Plugin {
 	 */
 	_setSelectionOverElement( element ) {
 		this.editor.model.change( writer => {
-			writer.setSelection( ModelRange.createOn( element ) );
+			writer.setSelection( writer.createRangeOn( element ) );
 		} );
 	}
 
@@ -365,11 +362,11 @@ export default class Widget extends Plugin {
 
 		// Clone current selection to use it as a probe. We must leave default selection as it is so it can return
 		// to its current state after undo.
-		const probe = new ModelSelection( modelSelection );
+		const probe = model.createSelection( modelSelection );
 		model.modifySelection( probe, { direction: forward ? 'forward' : 'backward' } );
 		const objectElement = forward ? probe.focus.nodeBefore : probe.focus.nodeAfter;
 
-		if ( objectElement instanceof ModelElement && schema.isObject( objectElement ) ) {
+		if ( !!objectElement && schema.isObject( objectElement ) ) {
 			return objectElement;
 		}
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -9,8 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import MouseObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mouseobserver';
-import ViewEditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement';
-import RootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditableelement';
 import { isWidget, WIDGET_SELECTED_CLASS_NAME, getLabel } from './utils';
 import { keyCodes, getCode, parseKeystroke } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
@@ -413,7 +411,7 @@ function isSelectAllKeyCode( domEventData ) {
 // @returns {Boolean}
 function isInsideNestedEditable( element ) {
 	while ( element ) {
-		if ( element instanceof ViewEditableElement && !( element instanceof RootEditableElement ) ) {
+		if ( !!element && element.is( 'editableElement' ) && !element.is( 'rootElement' ) ) {
 			return true;
 		}
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -366,7 +366,7 @@ describe( 'widget utils', () => {
 		it( 'returns position after selected element', () => {
 			setData( model, '<paragraph>x</paragraph>[<image></image>]<paragraph>y</paragraph>' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 2 ] );
 		} );
@@ -374,7 +374,7 @@ describe( 'widget utils', () => {
 		it( 'returns position inside empty block', () => {
 			setData( model, '<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>y</paragraph>' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 1, 0 ] );
 		} );
@@ -382,7 +382,7 @@ describe( 'widget utils', () => {
 		it( 'returns position before block if at the beginning of that block', () => {
 			setData( model, '<paragraph>x</paragraph><paragraph>[]foo</paragraph><paragraph>y</paragraph>' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 1 ] );
 		} );
@@ -390,7 +390,7 @@ describe( 'widget utils', () => {
 		it( 'returns position before block if in the middle of that block', () => {
 			setData( model, '<paragraph>x</paragraph><paragraph>f[]oo</paragraph><paragraph>y</paragraph>' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 1 ] );
 		} );
@@ -398,7 +398,7 @@ describe( 'widget utils', () => {
 		it( 'returns position after block if at the end of that block', () => {
 			setData( model, '<paragraph>x</paragraph><paragraph>foo[]</paragraph><paragraph>y</paragraph>' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 2 ] );
 		} );
@@ -407,7 +407,7 @@ describe( 'widget utils', () => {
 		it( 'returns position after block if at the end of that block (deeply nested)', () => {
 			setData( model, '<paragraph>x</paragraph><paragraph>foo<span>bar[]</span></paragraph><paragraph>y</paragraph>' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 2 ] );
 		} );
@@ -416,7 +416,7 @@ describe( 'widget utils', () => {
 			model.schema.extend( '$text', { allowIn: '$root' } );
 			setData( model, 'foo[]bar' );
 
-			const pos = findOptimalInsertionPosition( doc.selection );
+			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 3 ] );
 		} );

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -87,7 +87,7 @@ describe( 'Widget', () => {
 						view: ( modelItem, viewWriter ) => {
 							const b = viewWriter.createAttributeElement( 'b' );
 							const div = viewWriter.createContainerElement( 'div' );
-							viewWriter.insert( ViewPosition.createAt( div ), b );
+							viewWriter.insert( ViewPosition.createAt( div, 0 ), b );
 
 							return toWidget( div, viewWriter, { label: 'element label' } );
 						}

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -10,7 +10,6 @@ import MouseObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mouseobs
 import { downcastElementToElement } from '@ckeditor/ckeditor5-engine/src/conversion/downcast-converters';
 import { toWidget } from '../src/utils';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
-import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
 import { setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
@@ -87,7 +86,7 @@ describe( 'Widget', () => {
 						view: ( modelItem, viewWriter ) => {
 							const b = viewWriter.createAttributeElement( 'b' );
 							const div = viewWriter.createContainerElement( 'div' );
-							viewWriter.insert( ViewPosition.createAt( div, 0 ), b );
+							viewWriter.insert( viewWriter.createPositionAt( div, 0 ), b );
 
 							return toWidget( div, viewWriter, { label: 'element label' } );
 						}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove Position, Range, Selection imports from engine/model and engine/view.

BREAKING CHANGE: The `findOptimalPosition()` method now requires model instance as a second parameter.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5-engine/pull/1585.
