### PR TITLE
T/ckeditor5 table/99: Widget in editable should be clickable

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -415,7 +415,7 @@ function isSelectAllKeyCode( domEventData ) {
 // @returns {Boolean}
 function isInsideNestedEditable( element ) {
 	while ( element ) {
-		if ( !!element && element.is( 'editableElement' ) && !element.is( 'rootElement' ) ) {
+		if ( element.is( 'editableElement' ) && !element.is( 'rootElement' ) ) {
 			return true;
 		}
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -9,8 +9,8 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import MouseObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mouseobserver';
-import { isWidget, WIDGET_SELECTED_CLASS_NAME, getLabel } from './utils';
-import { keyCodes, getCode, parseKeystroke } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import { getLabel, isWidget, WIDGET_SELECTED_CLASS_NAME } from './utils';
+import { getCode, keyCodes, parseKeystroke } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
 import '../theme/widget.css';
 
@@ -417,6 +417,11 @@ function isInsideNestedEditable( element ) {
 	while ( element ) {
 		if ( element.is( 'editableElement' ) && !element.is( 'rootElement' ) ) {
 			return true;
+		}
+
+		// Click on nested widget should select it.
+		if ( isWidget( element ) ) {
+			return false;
 		}
 
 		element = element.parent;

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -201,13 +201,13 @@ describe( 'Widget', () => {
 		expect( viewDocument.selection.fakeSelectionLabel ).to.equal( 'element label' );
 	} );
 
-	it( 'should add selected class when no only a widget is selected', () => {
+	it( 'should add selected class when other content is selected with widget', () => {
 		setModelData( model, '[<paragraph>foo</paragraph><widget></widget><widget></widget>]' );
 
 		expect( viewDocument.selection.isFake ).to.be.false;
 		expect( getViewData( view ) ).to.equal(
-			'[' +
-			'<p>foo</p>' +
+
+			'<p>{foo</p>' +
 			'<div class="ck-widget ck-widget_selected" contenteditable="false"><b></b></div>' +
 			'<div class="ck-widget ck-widget_selected" contenteditable="false"><b></b></div>' +
 			']'

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -1349,5 +1349,31 @@ describe( 'Widget', () => {
 				'</div>'
 			);
 		} );
+
+		it( 'should select widget in editable', () => {
+			model.schema.extend( 'widget', { allowIn: 'nested' } );
+
+			setModelData( model, '[]<widget><nested><widget></widget></nested></widget>' );
+
+			const widgetInEditable = viewDocument.getRoot().getChild( 0 ).getChild( 0 ).getChild( 0 );
+
+			const domEventDataMock = {
+				target: widgetInEditable,
+				preventDefault: sinon.spy()
+			};
+
+			viewDocument.fire( 'mousedown', domEventDataMock );
+
+			expect( getViewData( view ) ).to.equal(
+				'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+					'<figcaption contenteditable="true">' +
+						'[<div class="ck-widget ck-widget_selectable ck-widget_selected" contenteditable="false">' +
+							'<div class="ck ck-widget__selection-handler"></div>' +
+						'</div>]' +
+					'</figcaption>' +
+					'<div class="ck ck-widget__selection-handler"></div>' +
+				'</div>'
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Make widget in editable clickable. Closes ckeditor/ckeditor5-table#98.

---

### Additional information

* Required for table PR: https://github.com/ckeditor/ckeditor5-table/pull/155.
* Requires fixes from engine: https://github.com/ckeditor/ckeditor5-engine/pull/1608.
