### PR TITLE
t/66: Renamed .ck-widget_selectable to .ck-widget_with-selection-handler.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -321,5 +321,5 @@ function addSelectionHandler( editable, writer ) {
 
 	// Append the selection handler into the widget wrapper.
 	writer.insert( writer.createPositionAt( editable, 0 ), selectionHandler );
-	writer.addClass( [ 'ck-widget_selectable' ], editable );
+	writer.addClass( [ 'ck-widget_with-selection-handler' ], editable );
 }

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -105,7 +105,7 @@ describe( 'widget utils', () => {
 		it( 'should add element a selection handler to widget if hasSelectionHandler=true is passed', () => {
 			toWidget( element, writer, { hasSelectionHandler: true } );
 
-			expect( element.hasClass( 'ck-widget_selectable' ) ).to.be.true;
+			expect( element.hasClass( 'ck-widget_with-selection-handler' ) ).to.be.true;
 
 			const selectionHandler = element.getChild( 0 );
 			expect( selectionHandler ).to.be.instanceof( UIElement );

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -1236,11 +1236,11 @@ describe( 'Widget', () => {
 			viewDocument.fire( 'mousedown', domEventDataMock );
 
 			expect( getViewData( view ) ).to.equal(
-				'[<div class="ck-widget ck-widget_selectable ck-widget_selected" contenteditable="false">' +
-					'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+				'[<div class="ck-widget ck-widget_with-selection-handler ck-widget_selected" contenteditable="false">' +
+					'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
 					'</div>' +
-					'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+					'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
 					'</div>' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
@@ -1268,19 +1268,19 @@ describe( 'Widget', () => {
 			viewDocument.fire( 'mousedown', domEventDataMock );
 
 			expect( getViewData( view ) ).to.equal(
-				'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+				'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
 				'</div>' +
-				'[<div class="ck-widget ck-widget_selectable ck-widget_selected" contenteditable="false">' +
-					'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+				'[<div class="ck-widget ck-widget_with-selection-handler ck-widget_selected" contenteditable="false">' +
+					'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
 					'</div>' +
-					'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+					'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
 					'</div>' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
 				'</div>]' +
-				'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+				'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
 				'</div>'
 			);
@@ -1304,9 +1304,9 @@ describe( 'Widget', () => {
 			viewDocument.fire( 'mousedown', domEventDataMock );
 
 			expect( getViewData( view ) ).to.equal(
-				'[<div class="ck-widget ck-widget_selectable ck-widget_selected" contenteditable="false">' +
+				'[<div class="ck-widget ck-widget_with-selection-handler ck-widget_selected" contenteditable="false">' +
 					'<figcaption contenteditable="true">foo bar</figcaption>' +
-					'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+					'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
 					'</div>' +
 					'<div class="ck ck-widget__selection-handler"></div>' +
@@ -1334,12 +1334,12 @@ describe( 'Widget', () => {
 			viewDocument.fire( 'mousedown', domEventDataMock );
 
 			expect( getViewData( view ) ).to.equal(
-				'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
-					'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+				'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
+					'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
 					'</div>' +
-					'[<div class="ck-widget ck-widget_selectable ck-widget_selected" contenteditable="false">' +
-						'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+					'[<div class="ck-widget ck-widget_with-selection-handler ck-widget_selected" contenteditable="false">' +
+						'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 							'<div class="ck ck-widget__selection-handler"></div>' +
 						'</div>' +
 						'<div class="ck ck-widget__selection-handler"></div>' +
@@ -1364,9 +1364,9 @@ describe( 'Widget', () => {
 			viewDocument.fire( 'mousedown', domEventDataMock );
 
 			expect( getViewData( view ) ).to.equal(
-				'<div class="ck-widget ck-widget_selectable" contenteditable="false">' +
+				'<div class="ck-widget ck-widget_with-selection-handler" contenteditable="false">' +
 					'<figcaption contenteditable="true">' +
-						'[<div class="ck-widget ck-widget_selectable ck-widget_selected" contenteditable="false">' +
+						'[<div class="ck-widget ck-widget_with-selection-handler ck-widget_selected" contenteditable="false">' +
 							'<div class="ck ck-widget__selection-handler"></div>' +
 						'</div>]' +
 					'</figcaption>' +

--- a/theme/widget.css
+++ b/theme/widget.css
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-.ck .ck-widget.ck-widget_selectable {
+.ck .ck-widget.ck-widget_with-selection-handler {
 	/* Make the widget wrapper a relative positioning container for the drag handler. */
 	position: relative;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Renamed the `.ck-widget_selectable` class to `.ck-widget_with-selection-handler` for better semantics. Closes #66.

BREAKING CHANGE: The `.ck-widget_selectable` class has been renamed to `.ck-widget_with-selection-handler` for better semantics.

---

### Additional information

Requires: 
* https://github.com/ckeditor/ckeditor5-theme-lark/pull/215
* https://github.com/ckeditor/ckeditor5-table/pull/165