### PR TITLE
t/ckeditor5/1520: Got rid of the symbol used to recognise view elements

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,9 +13,6 @@ import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import dragHandlerIcon from '../theme/icons/drag-handler.svg';
 
-const widgetSymbol = Symbol( 'isWidget' );
-const labelSymbol = Symbol( 'label' );
-
 /**
  * CSS class added to each widget element.
  *
@@ -37,11 +34,7 @@ export const WIDGET_SELECTED_CLASS_NAME = 'ck-widget_selected';
  * @returns {Boolean}
  */
 export function isWidget( node ) {
-	if ( !node.is( 'element' ) ) {
-		return false;
-	}
-
-	return !!node.getCustomProperty( widgetSymbol );
+	return node.is( 'element' ) && node.hasClass( WIDGET_CLASS_NAME );
 }
 
 /* eslint-disable max-len */
@@ -100,7 +93,6 @@ export function toWidget( element, writer, options = {} ) {
 	}
 
 	writer.addClass( WIDGET_CLASS_NAME, element );
-	writer.setCustomProperty( widgetSymbol, true, element );
 	element.getFillerOffset = getFillerOffset;
 
 	if ( options.label ) {
@@ -162,7 +154,7 @@ export function setHighlightHandling( element, writer, add, remove ) {
  * @param {module:engine/view/downcastwriter~DowncastWriter} writer
  */
 export function setLabel( element, labelOrCreator, writer ) {
-	writer.setCustomProperty( labelSymbol, labelOrCreator, element );
+	writer.setCustomProperty( 'widgetLabel', labelOrCreator, element );
 }
 
 /**
@@ -172,7 +164,7 @@ export function setLabel( element, labelOrCreator, writer ) {
  * @returns {String}
  */
 export function getLabel( element ) {
-	const labelCreator = element.getCustomProperty( labelSymbol );
+	const labelCreator = element.getCustomProperty( 'widgetLabel' );
 
 	if ( !labelCreator ) {
 		return '';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Got rid of the symbol used to recognize view elements (see ckeditor/ckeditor5#1520).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1521
