### PR TITLE
t/ckeditor5/1520b: Got rid of the Symbols used to recognize view elements; replaced with strings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,9 +13,6 @@ import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import dragHandlerIcon from '../theme/icons/drag-handler.svg';
 
-const widgetSymbol = Symbol( 'isWidget' );
-const labelSymbol = Symbol( 'label' );
-
 /**
  * CSS class added to each widget element.
  *
@@ -41,7 +38,7 @@ export function isWidget( node ) {
 		return false;
 	}
 
-	return !!node.getCustomProperty( widgetSymbol );
+	return !!node.getCustomProperty( 'widget' );
 }
 
 /* eslint-disable max-len */
@@ -100,7 +97,7 @@ export function toWidget( element, writer, options = {} ) {
 	}
 
 	writer.addClass( WIDGET_CLASS_NAME, element );
-	writer.setCustomProperty( widgetSymbol, true, element );
+	writer.setCustomProperty( 'widget', true, element );
 	element.getFillerOffset = getFillerOffset;
 
 	if ( options.label ) {
@@ -162,7 +159,7 @@ export function setHighlightHandling( element, writer, add, remove ) {
  * @param {module:engine/view/downcastwriter~DowncastWriter} writer
  */
 export function setLabel( element, labelOrCreator, writer ) {
-	writer.setCustomProperty( labelSymbol, labelOrCreator, element );
+	writer.setCustomProperty( 'widgetLabel', labelOrCreator, element );
 }
 
 /**
@@ -172,7 +169,7 @@ export function setLabel( element, labelOrCreator, writer ) {
  * @returns {String}
  */
 export function getLabel( element ) {
-	const labelCreator = element.getCustomProperty( labelSymbol );
+	const labelCreator = element.getCustomProperty( 'widgetLabel' );
 
 	if ( !labelCreator ) {
 		return '';

--- a/tests/widgettoolbarrepository.js
+++ b/tests/widgettoolbarrepository.js
@@ -333,13 +333,10 @@ describe( 'WidgetToolbarRepository - integration with the BalloonToolbar', () =>
 	} );
 } );
 
-const fakeWidgetSymbol = Symbol( 'fakeWidget' );
-const fakeChildWidgetSymbol = Symbol( 'fakeChildWidget' );
-
 function getSelectedFakeWidget( selection ) {
 	const viewElement = selection.getSelectedElement();
 
-	if ( viewElement && isWidget( viewElement ) && !!viewElement.getCustomProperty( fakeWidgetSymbol ) ) {
+	if ( viewElement && isWidget( viewElement ) && !!viewElement.getCustomProperty( 'fakeWidget' ) ) {
 		return viewElement;
 	}
 
@@ -349,7 +346,7 @@ function getSelectedFakeWidget( selection ) {
 function getSelectedFakeChildWidget( selection ) {
 	const viewElement = selection.getSelectedElement();
 
-	if ( viewElement && isWidget( viewElement ) && !!viewElement.getCustomProperty( fakeChildWidgetSymbol ) ) {
+	if ( viewElement && isWidget( viewElement ) && !!viewElement.getCustomProperty( 'fakeChildWidget' ) ) {
 		return viewElement;
 	}
 
@@ -361,7 +358,7 @@ function getSelectedFakeWidgetContent( selection ) {
 	let node = pos.parent;
 
 	while ( node ) {
-		if ( node.is( 'element' ) && isWidget( node ) && node.getCustomProperty( fakeWidgetSymbol ) ) {
+		if ( node.is( 'element' ) && isWidget( node ) && node.getCustomProperty( 'fakeWidget' ) ) {
 			return node;
 		}
 
@@ -420,7 +417,7 @@ class FakeWidget extends Plugin {
 			model: 'fake-widget',
 			view: ( modelElement, viewWriter ) => {
 				const fakeWidget = viewWriter.createContainerElement( 'div' );
-				viewWriter.setCustomProperty( fakeWidgetSymbol, true, fakeWidget );
+				viewWriter.setCustomProperty( 'fakeWidget', true, fakeWidget );
 
 				return toWidget( fakeWidget, viewWriter, { label: 'fake-widget' } );
 			}
@@ -472,7 +469,7 @@ class FakeChildWidget extends Plugin {
 			model: 'fake-child-widget',
 			view: ( modelElement, viewWriter ) => {
 				const fakeWidget = viewWriter.createContainerElement( 'div' );
-				viewWriter.setCustomProperty( fakeChildWidgetSymbol, true, fakeWidget );
+				viewWriter.setCustomProperty( 'fakeChildWidget', true, fakeWidget );
 
 				return toWidget( fakeWidget, viewWriter, { label: 'fake-child-widget' } );
 			}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Got rid of the Symbols used to recognize view elements; replaced with strings (see ckeditor/ckeditor5#1520).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1532 constellation.
