### PR TITLE
Improve caret between inline widget rendering in manual tests.

### DIFF
--- a/tests/manual/inline-widget.html
+++ b/tests/manual/inline-widget.html
@@ -14,6 +14,10 @@
 		padding: 4px 2px;
 		outline-offset: -2px;
 		line-height: 1em;
+		/* Set margins before and after the inline widget so the cursor between two instances is visible when one of them is focused.
+		   Optimized for Firefox due to bug in rendering selection in ZWS on Chrome. See ckeditor5#1607. */
+		margin-right: 1px;
+		margin-left: 3px;
 	}
 
 	placeholder::selection {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Improve caret between inline widget rendering in manual tests. Closes ckeditor/ckeditor5#1571.

---

### Additional information

* The new bug found: https://github.com/ckeditor/ckeditor5/issues/1607
