### PR TITLE
Fixed an issue with triple click in nested editable.

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -114,8 +114,18 @@ export default class Widget extends Plugin {
 		const viewDocument = view.document;
 		let element = domEventData.target;
 
-		// Do nothing if inside nested editable.
+		// Do nothing for single or double click inside nested editable.
 		if ( isInsideNestedEditable( element ) ) {
+			// But at least triple click inside nested editable causes broken selection in Safari.
+			// For such event, we select the entire nested editable element.
+			// See: https://github.com/ckeditor/ckeditor5/issues/1463.
+			if ( domEventData.domEvent.detail >= 3 ) {
+				this.editor.editing.view.change( writer => {
+					domEventData.preventDefault();
+					writer.setSelection( element, 'in' );
+				} );
+			}
+
 			return;
 		}
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -11,6 +11,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import MouseObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mouseobserver';
 import { getLabel, isWidget, WIDGET_SELECTED_CLASS_NAME } from './utils';
 import { getCode, keyCodes, parseKeystroke } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import '../theme/widget.css';
 
@@ -119,7 +120,7 @@ export default class Widget extends Plugin {
 			// But at least triple click inside nested editable causes broken selection in Safari.
 			// For such event, we select the entire nested editable element.
 			// See: https://github.com/ckeditor/ckeditor5/issues/1463.
-			if ( domEventData.domEvent.detail >= 3 ) {
+			if ( env.isSafari && domEventData.domEvent.detail >= 3 ) {
 				this.editor.editing.view.change( writer => {
 					domEventData.preventDefault();
 					writer.setSelection( element, 'in' );

--- a/tests/widget-integration.js
+++ b/tests/widget-integration.js
@@ -1,0 +1,209 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Widget from '../src/widget';
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
+
+import { toWidget } from '../src/utils';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
+
+import env from '@ckeditor/ckeditor5-utils/src/env';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
+/* global document */
+
+describe( 'Widget - integration', () => {
+	let editor, model, view, viewDocument, editorElement;
+
+	testUtils.createSinonSandbox();
+
+	beforeEach( () => {
+		// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
+		testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+
+		editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		return ClassicEditor.create( editorElement, { plugins: [ Widget, Typing ] } )
+			.then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+				view = editor.editing.view;
+				viewDocument = view.document;
+
+				model.schema.register( 'widget', {
+					inheritAllFrom: '$block',
+					isObject: true
+				} );
+				model.schema.register( 'paragraph', {
+					inheritAllFrom: '$block',
+					allowIn: '$root'
+				} );
+				model.schema.register( 'nested', {
+					allowIn: 'widget',
+					isLimit: true
+				} );
+				model.schema.extend( '$text', {
+					allowIn: [ 'nested', 'editable', 'inline-widget' ]
+				} );
+				model.schema.register( 'editable', {
+					allowIn: [ 'widget', '$root' ]
+				} );
+				model.schema.register( 'inline-widget', {
+					allowWhere: '$text',
+					isObject: true,
+					isInline: true
+				} );
+
+				editor.conversion.for( 'downcast' )
+					.elementToElement( { model: 'paragraph', view: 'p' } )
+					.elementToElement( { model: 'inline', view: 'figure' } )
+					.elementToElement( { model: 'image', view: 'img' } )
+					.elementToElement( {
+						model: 'widget',
+						view: ( modelItem, viewWriter ) => {
+							const b = viewWriter.createAttributeElement( 'b' );
+							const div = viewWriter.createContainerElement( 'div' );
+							viewWriter.insert( viewWriter.createPositionAt( div, 0 ), b );
+
+							return toWidget( div, viewWriter, { label: 'element label' } );
+						}
+					} )
+					.elementToElement( {
+						model: 'inline-widget',
+						view: ( modelItem, viewWriter ) => {
+							const span = viewWriter.createContainerElement( 'span' );
+
+							return toWidget( span, viewWriter );
+						}
+					} )
+					.elementToElement( {
+						model: 'nested',
+						view: ( modelItem, viewWriter ) => viewWriter.createEditableElement( 'figcaption', { contenteditable: true } )
+					} )
+					.elementToElement( {
+						model: 'editable',
+						view: ( modelItem, viewWriter ) => viewWriter.createEditableElement( 'figcaption', { contenteditable: true } )
+					} );
+			} );
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+	} );
+
+	it( 'should do nothing if clicked inside nested editable', () => {
+		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+		const viewDiv = viewDocument.getRoot().getChild( 0 );
+		const viewFigcaption = viewDiv.getChild( 0 );
+
+		const preventDefault = sinon.spy();
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( viewFigcaption ),
+			preventDefault,
+			detail: 1
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.notCalled( preventDefault );
+
+		expect( getViewData( view ) ).to.equal(
+			'[]<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">foo bar</figcaption><b></b></div>'
+		);
+	} );
+
+	it( 'should select the entire nested editable if triple clicked', () => {
+		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+		const viewDiv = viewDocument.getRoot().getChild( 0 );
+		const viewFigcaption = viewDiv.getChild( 0 );
+		const preventDefault = sinon.spy();
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( viewFigcaption ),
+			preventDefault,
+			detail: 3
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.called( preventDefault );
+
+		expect( getViewData( view ) ).to.equal(
+			'<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">[foo bar]</figcaption><b></b></div>'
+		);
+	} );
+
+	it( 'should select proper nested editable if triple clicked', () => {
+		setModelData( model, '[]<widget><nested>foo</nested><nested>bar</nested></widget>' );
+		const viewDiv = viewDocument.getRoot().getChild( 0 );
+		const secondViewFigcaption = viewDiv.getChild( 1 );
+		const preventDefault = sinon.spy();
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( secondViewFigcaption ),
+			preventDefault,
+			detail: 3
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.called( preventDefault );
+
+		expect( getViewData( view ) ).to.equal(
+			'<div class="ck-widget" contenteditable="false">' +
+				'<figcaption contenteditable="true">foo</figcaption>' +
+				'<figcaption contenteditable="true">[bar]</figcaption><b></b>' +
+			'</div>'
+		);
+	} );
+
+	it( 'should select the entire nested editable if quadra clicked', () => {
+		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+		const viewDiv = viewDocument.getRoot().getChild( 0 );
+		const viewFigcaption = viewDiv.getChild( 0 );
+
+		const preventDefault = sinon.spy();
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( viewFigcaption ),
+			preventDefault,
+			detail: 4
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.called( preventDefault );
+
+		expect( getViewData( view ) ).to.equal(
+			'<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">[foo bar]</figcaption><b></b></div>'
+		);
+	} );
+
+	it( 'should select the inline widget if triple clicked', () => {
+		setModelData( model, '<paragraph>Foo<inline-widget>foo bar</inline-widget>Bar</paragraph>' );
+		const viewParagraph = viewDocument.getRoot().getChild( 0 );
+		const viewInlineWidget = viewParagraph.getChild( 1 );
+		const preventDefault = sinon.spy();
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( viewInlineWidget ),
+			preventDefault,
+			detail: 3
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.called( preventDefault );
+
+		expect( getViewData( view ) ).to.equal(
+			'<p>Foo{<span class="ck-widget ck-widget_selected" contenteditable="false">foo bar</span>}Bar</p>'
+		);
+	} );
+} );

--- a/tests/widget-integration.js
+++ b/tests/widget-integration.js
@@ -67,9 +67,7 @@ describe( 'Widget - integration', () => {
 					.elementToElement( {
 						model: 'widget',
 						view: ( modelItem, viewWriter ) => {
-							const b = viewWriter.createAttributeElement( 'b' );
 							const div = viewWriter.createContainerElement( 'div' );
-							viewWriter.insert( viewWriter.createPositionAt( div, 0 ), b );
 
 							return toWidget( div, viewWriter, { label: 'element label' } );
 						}
@@ -115,7 +113,7 @@ describe( 'Widget - integration', () => {
 		sinon.assert.notCalled( preventDefault );
 
 		expect( getViewData( view ) ).to.equal(
-			'[]<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">foo bar</figcaption><b></b></div>'
+			'[]<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">foo bar</figcaption></div>'
 		);
 	} );
 
@@ -136,7 +134,7 @@ describe( 'Widget - integration', () => {
 		sinon.assert.called( preventDefault );
 
 		expect( getViewData( view ) ).to.equal(
-			'<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">[foo bar]</figcaption><b></b></div>'
+			'<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">[foo bar]</figcaption></div>'
 		);
 	} );
 
@@ -159,7 +157,7 @@ describe( 'Widget - integration', () => {
 		expect( getViewData( view ) ).to.equal(
 			'<div class="ck-widget" contenteditable="false">' +
 				'<figcaption contenteditable="true">foo</figcaption>' +
-				'<figcaption contenteditable="true">[bar]</figcaption><b></b>' +
+				'<figcaption contenteditable="true">[bar]</figcaption>' +
 			'</div>'
 		);
 	} );
@@ -182,7 +180,7 @@ describe( 'Widget - integration', () => {
 		sinon.assert.called( preventDefault );
 
 		expect( getViewData( view ) ).to.equal(
-			'<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">[foo bar]</figcaption><b></b></div>'
+			'<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">[foo bar]</figcaption></div>'
 		);
 	} );
 

--- a/tests/widget-integration.js
+++ b/tests/widget-integration.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global document */
+
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Widget from '../src/widget';
@@ -14,8 +16,6 @@ import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils
 
 import env from '@ckeditor/ckeditor5-utils/src/env';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-
-/* global document */
 
 describe( 'Widget - integration', () => {
 	let editor, model, view, viewDocument, editorElement;
@@ -94,9 +94,11 @@ describe( 'Widget - integration', () => {
 
 	afterEach( () => {
 		editorElement.remove();
+
+		return editor.destroy();
 	} );
 
-	it( 'should do nothing if clicked inside nested editable', () => {
+	it( 'should do nothing if clicked inside a nested editable', () => {
 		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
 		const viewDiv = viewDocument.getRoot().getChild( 0 );
 		const viewFigcaption = viewDiv.getChild( 0 );
@@ -120,10 +122,10 @@ describe( 'Widget - integration', () => {
 
 	it( 'should select the entire nested editable if triple clicked', () => {
 		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+
 		const viewDiv = viewDocument.getRoot().getChild( 0 );
 		const viewFigcaption = viewDiv.getChild( 0 );
 		const preventDefault = sinon.spy();
-
 		const domEventDataMock = new DomEventData( view, {
 			target: view.domConverter.mapViewToDom( viewFigcaption ),
 			preventDefault,
@@ -141,10 +143,10 @@ describe( 'Widget - integration', () => {
 
 	it( 'should select proper nested editable if triple clicked', () => {
 		setModelData( model, '[]<widget><nested>foo</nested><nested>bar</nested></widget>' );
+
 		const viewDiv = viewDocument.getRoot().getChild( 0 );
 		const secondViewFigcaption = viewDiv.getChild( 1 );
 		const preventDefault = sinon.spy();
-
 		const domEventDataMock = new DomEventData( view, {
 			target: view.domConverter.mapViewToDom( secondViewFigcaption ),
 			preventDefault,
@@ -165,11 +167,10 @@ describe( 'Widget - integration', () => {
 
 	it( 'should select the entire nested editable if quadra clicked', () => {
 		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+
 		const viewDiv = viewDocument.getRoot().getChild( 0 );
 		const viewFigcaption = viewDiv.getChild( 0 );
-
 		const preventDefault = sinon.spy();
-
 		const domEventDataMock = new DomEventData( view, {
 			target: view.domConverter.mapViewToDom( viewFigcaption ),
 			preventDefault,
@@ -187,10 +188,10 @@ describe( 'Widget - integration', () => {
 
 	it( 'should select the inline widget if triple clicked', () => {
 		setModelData( model, '<paragraph>Foo<inline-widget>foo bar</inline-widget>Bar</paragraph>' );
+
 		const viewParagraph = viewDocument.getRoot().getChild( 0 );
 		const viewInlineWidget = viewParagraph.getChild( 1 );
 		const preventDefault = sinon.spy();
-
 		const domEventDataMock = new DomEventData( view, {
 			target: view.domConverter.mapViewToDom( viewInlineWidget ),
 			preventDefault,
@@ -210,11 +211,10 @@ describe( 'Widget - integration', () => {
 		testUtils.sinon.stub( env, 'isSafari' ).get( () => false );
 
 		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+
 		const viewDiv = viewDocument.getRoot().getChild( 0 );
 		const viewFigcaption = viewDiv.getChild( 0 );
-
 		const preventDefault = sinon.spy();
-
 		const domEventDataMock = new DomEventData( view, {
 			target: view.domConverter.mapViewToDom( viewFigcaption ),
 			preventDefault,

--- a/tests/widget-integration.js
+++ b/tests/widget-integration.js
@@ -25,6 +25,7 @@ describe( 'Widget - integration', () => {
 	beforeEach( () => {
 		// Most tests assume non-edge environment but we do not set `contenteditable=false` on Edge so stub `env.isEdge`.
 		testUtils.sinon.stub( env, 'isEdge' ).get( () => false );
+		testUtils.sinon.stub( env, 'isSafari' ).get( () => true );
 
 		editorElement = document.createElement( 'div' );
 		document.body.appendChild( editorElement );
@@ -202,6 +203,30 @@ describe( 'Widget - integration', () => {
 
 		expect( getViewData( view ) ).to.equal(
 			'<p>Foo{<span class="ck-widget ck-widget_selected" contenteditable="false">foo bar</span>}Bar</p>'
+		);
+	} );
+
+	it( 'should does nothing for non-Safari browser', () => {
+		testUtils.sinon.stub( env, 'isSafari' ).get( () => false );
+
+		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
+		const viewDiv = viewDocument.getRoot().getChild( 0 );
+		const viewFigcaption = viewDiv.getChild( 0 );
+
+		const preventDefault = sinon.spy();
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( viewFigcaption ),
+			preventDefault,
+			detail: 4
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.notCalled( preventDefault );
+
+		expect( getViewData( view ) ).to.equal(
+			'[]<div class="ck-widget" contenteditable="false"><figcaption contenteditable="true">foo bar</figcaption></div>'
 		);
 	} );
 } );

--- a/tests/widget.js
+++ b/tests/widget.js
@@ -151,21 +151,6 @@ describe( 'Widget', () => {
 		sinon.assert.calledOnce( domEventDataMock.preventDefault );
 	} );
 
-	it( 'should do nothing if clicked inside nested editable', () => {
-		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
-		const viewDiv = viewDocument.getRoot().getChild( 0 );
-		const viewFigcaption = viewDiv.getChild( 0 );
-
-		const domEventDataMock = {
-			target: viewFigcaption,
-			preventDefault: sinon.spy()
-		};
-
-		viewDocument.fire( 'mousedown', domEventDataMock );
-
-		sinon.assert.notCalled( domEventDataMock.preventDefault );
-	} );
-
 	it( 'should do nothing if clicked in non-widget element', () => {
 		setModelData( model, '<paragraph>[]foo bar</paragraph><widget></widget>' );
 		const viewP = viewDocument.getRoot().getChild( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed a weird selection behavior on at least triple click. Triple click inside the nested editable will select the entire element now. Closes ckeditor/ckeditor5#1463.

---

Requires: https://github.com/ckeditor/ckeditor5-utils/pull/278.