### PR TITLE
Use proper method to map a view to a DOM element in getBalloonPositio…

### DIFF
--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -243,7 +243,7 @@ function getBalloonPositionData( editor, relatedElement ) {
 	const defaultPositions = BalloonPanelView.defaultPositions;
 
 	return {
-		target: editingView.domConverter.viewToDom( relatedElement ),
+		target: editingView.domConverter.mapViewToDom( relatedElement ),
 		positions: [
 			defaultPositions.northArrowSouth,
 			defaultPositions.northArrowSouthWest,


### PR DESCRIPTION
Use proper method to map a view to a DOM element in getBalloonPositionData().

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Use proper method to map a view to a DOM element when getting balloon position data. Closes #87.

---

### Additional information

* I don't see a need for adding tests as this is more a typo then a bug but feel free to R- this :)
