### PR TITLE
Improved balloon positioning when there is more than one stack in the rotator

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^11.1.3",
+    "@ckeditor/ckeditor5-block-quote": "^11.1.2",
     "@ckeditor/ckeditor5-clipboard": "^12.0.1",
     "@ckeditor/ckeditor5-editor-balloon": "^12.2.1",
     "@ckeditor/ckeditor5-editor-classic": "^12.1.3",

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -187,6 +187,7 @@ export default class WidgetToolbarRepository extends Plugin {
 	 */
 	_hideToolbar( toolbarDefinition ) {
 		this._balloon.remove( toolbarDefinition.view );
+		this.stopListening( this._balloon, 'change:visibleView' );
 	}
 
 	/**
@@ -208,6 +209,18 @@ export default class WidgetToolbarRepository extends Plugin {
 				view: toolbarDefinition.view,
 				position: getBalloonPositionData( this.editor, relatedElement ),
 				balloonClassName: toolbarDefinition.balloonClassName,
+			} );
+
+			// Update toolbar position each time stack with toolbar view is switched to visible.
+			// This is in a case target element has changed when toolbar was in invisible stack
+			// e.g. target image was wrapper by a block quote.
+			// See https://github.com/ckeditor/ckeditor5-widget/issues/92.
+			this.listenTo( this._balloon, 'change:visibleView', () => {
+				for ( const definition of this._toolbarDefinitions.values() ) {
+					if ( this._isToolbarVisible( definition ) ) {
+						this._updateToolbarsVisibility( definition );
+					}
+				}
 			} );
 		}
 	}

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -213,7 +213,7 @@ export default class WidgetToolbarRepository extends Plugin {
 
 			// Update toolbar position each time stack with toolbar view is switched to visible.
 			// This is in a case target element has changed when toolbar was in invisible stack
-			// e.g. target image was wrapper by a block quote.
+			// e.g. target image was wrapped by a block quote.
 			// See https://github.com/ckeditor/ckeditor5-widget/issues/92.
 			this.listenTo( this._balloon, 'change:visibleView', () => {
 				for ( const definition of this._toolbarDefinitions.values() ) {

--- a/tests/widgettoolbarrepository.js
+++ b/tests/widgettoolbarrepository.js
@@ -333,7 +333,42 @@ describe( 'WidgetToolbarRepository', () => {
 				view.domConverter.viewToDom( fakeChildViewElement ) );
 		} );
 
-		it( 'should update position when is switched in rotator to a visible panel', () => {
+		it( 'should not update balloon position when toolbar is in not visible stack', () => {
+			const customView = new View();
+
+			sinon.spy( balloon.view, 'pin' );
+
+			widgetToolbarRepository.register( 'fake', {
+				items: editor.config.get( 'fake.toolbar' ),
+				getRelatedElement: getSelectedFakeWidget
+			} );
+
+			setData( model,
+				'<paragraph>foo</paragraph>' +
+				'[<fake-widget></fake-widget>]'
+			);
+
+			balloon.add( {
+				stackId: 'custom',
+				view: customView,
+				position: { target: {} }
+			} );
+
+			balloon.showStack( 'custom' );
+
+			const fakeWidgetToolbarView = widgetToolbarRepository._toolbarDefinitions.get( 'fake' ).view;
+
+			expect( balloon.visibleView ).to.equal( customView );
+			expect( balloon.hasView( fakeWidgetToolbarView ) ).to.equal( true );
+
+			const spy = testUtils.sinon.spy( balloon, 'updatePosition' );
+
+			editor.ui.fire( 'update' );
+
+			sinon.assert.notCalled( spy );
+		} );
+
+		it( 'should update balloon position when stack with toolbar is switched in rotator to visible', () => {
 			const view = editor.editing.view;
 			const customView = new View();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved balloon positioning when there is more than one stack in the rotator. Closes #92.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
