### PR TITLE
Fixed resizer initial percentage values for side images

### DIFF
--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -467,7 +467,7 @@ class SizeView extends View {
 	}
 }
 
-// @param
+// @private
 // @param {String} resizerPosition Expected resizer position like `"top-left"`, `"bottom-right"`.
 // @returns {String} A prefixed HTML class name for the resizer element
 function getResizerClass( resizerPosition ) {

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -467,6 +467,7 @@ class SizeView extends View {
 	}
 }
 
+// @param
 // @param {String} resizerPosition Expected resizer position like `"top-left"`, `"bottom-right"`.
 // @returns {String} A prefixed HTML class name for the resizer element
 function getResizerClass( resizerPosition ) {

--- a/src/widgetresize/resizerstate.js
+++ b/src/widgetresize/resizerstate.js
@@ -126,11 +126,8 @@ export default class ResizeState {
 
 		const widthStyle = domResizeHost.style.width;
 
-		if ( widthStyle && widthStyle.match( /^\d+\.?\d*%$/ ) ) {
-			this.originalWidthPercents = parseFloat( widthStyle );
-		} else {
-			this.originalWidthPercents = this._getParentPercentage( domResizeHost );
-		}
+		this.originalWidthPercents = widthStyle && widthStyle.match( /^\d+\.?\d*%$/ ) ?
+			parseFloat( widthStyle ) : calculateHostPercentageWidth( domResizeHost );
 	}
 
 	update( newSize ) {
@@ -141,26 +138,25 @@ export default class ResizeState {
 		this.proposedHandleHostWidth = newSize.handleHostWidth;
 		this.proposedHandleHostHeight = newSize.handleHostHeight;
 	}
-
-	/**
-	 * Calculates a relative width of a `domResizeHost` compared to it's parent in percents.
-	 *
-	 * @protected
-	 * @param {HTMLElement} domResizeHost
-	 * @returns {Number}
-	 */
-	_getParentPercentage( domResizeHost ) {
-		const rect = new Rect( domResizeHost );
-		const domResizeHostParent = domResizeHost.parentElement;
-		// Need to use computed style as it properly excludes parent's paddings from the returned value.
-		const parentWidth = parseFloat( domResizeHostParent.ownerDocument.defaultView.getComputedStyle( domResizeHostParent ).width );
-
-		// Round to two digits in fraction.
-		return Math.round( rect.width / parentWidth * 10000 ) / 100;
-	}
 }
 
 mix( ResizeState, ObservableMixin );
+
+/**
+ * Calculates a relative width of a `domResizeHost` compared to it's parent in percents.
+ *
+ * @private
+ * @param {HTMLElement} domResizeHost
+ * @returns {Number}
+ */
+function calculateHostPercentageWidth( domResizeHost ) {
+	const rect = new Rect( domResizeHost );
+	const domResizeHostParent = domResizeHost.parentElement;
+	// Need to use computed style as it properly excludes parent's paddings from the returned value.
+	const parentWidth = parseFloat( domResizeHostParent.ownerDocument.defaultView.getComputedStyle( domResizeHostParent ).width );
+	// Round to two digits in fraction.
+	return Math.round( rect.width / parentWidth * 10000 ) / 100;
+}
 
 /**
  * Returns coordinates of the top-left corner of an element, relative to the document's top-left corner.

--- a/src/widgetresize/resizerstate.js
+++ b/src/widgetresize/resizerstate.js
@@ -127,7 +127,7 @@ export default class ResizeState {
 		const widthStyle = domResizeHost.style.width;
 
 		this.originalWidthPercents = widthStyle && widthStyle.match( /^\d+\.?\d*%$/ ) ?
-			parseFloat( widthStyle ) : calculateHostPercentageWidth( domResizeHost );
+			parseFloat( widthStyle ) : calculateHostPercentageWidth( domResizeHost, clientRect );
 	}
 
 	update( newSize ) {
@@ -147,15 +147,15 @@ mix( ResizeState, ObservableMixin );
  *
  * @private
  * @param {HTMLElement} domResizeHost
+ * @param {module:utils/dom/rect~Rect} resizeHostRect
  * @returns {Number}
  */
-function calculateHostPercentageWidth( domResizeHost ) {
-	const rect = new Rect( domResizeHost );
+function calculateHostPercentageWidth( domResizeHost, resizeHostRect ) {
 	const domResizeHostParent = domResizeHost.parentElement;
 	// Need to use computed style as it properly excludes parent's paddings from the returned value.
 	const parentWidth = parseFloat( domResizeHostParent.ownerDocument.defaultView.getComputedStyle( domResizeHostParent ).width );
-	// Round to two digits in fraction.
-	return Math.round( rect.width / parentWidth * 10000 ) / 100;
+
+	return resizeHostRect.width / parentWidth * 100;
 }
 
 /**

--- a/src/widgetresize/resizerstate.js
+++ b/src/widgetresize/resizerstate.js
@@ -142,14 +142,12 @@ export default class ResizeState {
 
 mix( ResizeState, ObservableMixin );
 
-/**
- * Calculates a relative width of a `domResizeHost` compared to it's parent in percents.
- *
- * @private
- * @param {HTMLElement} domResizeHost
- * @param {module:utils/dom/rect~Rect} resizeHostRect
- * @returns {Number}
- */
+// Calculates a relative width of a `domResizeHost` compared to it's parent in percents.
+//
+// @private
+// @param {HTMLElement} domResizeHost
+// @param {module:utils/dom/rect~Rect} resizeHostRect
+// @returns {Number}
 function calculateHostPercentageWidth( domResizeHost, resizeHostRect ) {
 	const domResizeHostParent = domResizeHost.parentElement;
 	// Need to use computed style as it properly excludes parent's paddings from the returned value.
@@ -158,16 +156,14 @@ function calculateHostPercentageWidth( domResizeHost, resizeHostRect ) {
 	return resizeHostRect.width / parentWidth * 100;
 }
 
-/**
- * Returns coordinates of the top-left corner of an element, relative to the document's top-left corner.
- *
- * @private
- * @param {HTMLElement} element
- * @param {String} resizerPosition The position of the resize handle, e.g. `"top-left"`, `"bottom-right"`.
- * @returns {Object} return
- * @returns {Number} return.x
- * @returns {Number} return.y
- */
+// Returns coordinates of the top-left corner of an element, relative to the document's top-left corner.
+//
+// @private
+// @param {HTMLElement} element
+// @param {String} resizerPosition The position of the resize handle, e.g. `"top-left"`, `"bottom-right"`.
+// @returns {Object} return
+// @returns {Number} return.x
+// @returns {Number} return.y
 function getAbsoluteBoundaryPoint( element, resizerPosition ) {
 	const elementRect = new Rect( element );
 	const positionParts = resizerPosition.split( '-' );
@@ -182,22 +178,18 @@ function getAbsoluteBoundaryPoint( element, resizerPosition ) {
 	return ret;
 }
 
-/**
- * @private
- * @param {String} resizerPosition The expected resizer position, like `"top-left"`, `"bottom-right"`.
- * @returns {String} A prefixed HTML class name for the resizer element.
- */
+// @private
+// @param {String} resizerPosition The expected resizer position, like `"top-left"`, `"bottom-right"`.
+// @returns {String} A prefixed HTML class name for the resizer element.
 function getResizerHandleClass( resizerPosition ) {
 	return `ck-widget__resizer__handle-${ resizerPosition }`;
 }
 
-/**
- * Determines the position of a given resize handle.
- *
- * @private
- * @param {HTMLElement} domHandle Handler used to calculate the reference point.
- * @returns {String|undefined} Returns a string like `"top-left"` or `undefined` if not matched.
- */
+// Determines the position of a given resize handle.
+//
+// @private
+// @param {HTMLElement} domHandle Handler used to calculate the reference point.
+// @returns {String|undefined} Returns a string like `"top-left"` or `undefined` if not matched.
 function getHandlePosition( domHandle ) {
 	const resizerPositions = [ 'top-left', 'top-right', 'bottom-right', 'bottom-left' ];
 
@@ -208,10 +200,9 @@ function getHandlePosition( domHandle ) {
 	}
 }
 
-/**
- * @param {String} position Like `"top-left"`.
- * @returns {String} Inverted `position`, e.g. it returns `"bottom-right"` if `"top-left"` was given as `position`.
- */
+// @private
+// @param {String} position Like `"top-left"`.
+// @returns {String} Inverted `position`, e.g. it returns `"bottom-right"` if `"top-left"` was given as `position`.
 function getOppositePosition( position ) {
 	const parts = position.split( '-' );
 	const replacements = {

--- a/src/widgetresize/resizerstate.js
+++ b/src/widgetresize/resizerstate.js
@@ -134,7 +134,7 @@ export default class ResizeState {
 				this.originalWidthPercents = 50;
 			}
 		} else {
-			this.originalWidthPercents = 100;
+			this.originalWidthPercents = this._getParentPercentage( domResizeHost );
 		}
 	}
 
@@ -145,6 +145,23 @@ export default class ResizeState {
 
 		this.proposedHandleHostWidth = newSize.handleHostWidth;
 		this.proposedHandleHostHeight = newSize.handleHostHeight;
+	}
+
+	/**
+	 * Calculates a relative width of a `domResizeHost` compared to it's parent in percents.
+	 *
+	 * @protected
+	 * @param {HTMLElement} domResizeHost
+	 * @returns {Number}
+	 */
+	_getParentPercentage( domResizeHost ) {
+		const rect = new Rect( domResizeHost );
+		const domResizeHostParent = domResizeHost.parentElement;
+		// Need to use computed style as it properly excludes parent's paddings from the returned value.
+		const parentWidth = parseFloat( domResizeHostParent.ownerDocument.defaultView.getComputedStyle( domResizeHostParent ).width );
+
+		// Round to two digits in fraction.
+		return Math.round( rect.width / parentWidth * 10000 ) / 100;
 	}
 }
 

--- a/src/widgetresize/resizerstate.js
+++ b/src/widgetresize/resizerstate.js
@@ -126,13 +126,8 @@ export default class ResizeState {
 
 		const widthStyle = domResizeHost.style.width;
 
-		if ( widthStyle ) {
-			if ( widthStyle.match( /^\d+\.?\d*%$/ ) ) {
-				this.originalWidthPercents = parseFloat( widthStyle );
-			} else {
-				// TODO we need to check it via comparing to the parent's width.
-				this.originalWidthPercents = 50;
-			}
+		if ( widthStyle && widthStyle.match( /^\d+\.?\d*%$/ ) ) {
+			this.originalWidthPercents = parseFloat( widthStyle );
 		} else {
 			this.originalWidthPercents = this._getParentPercentage( domResizeHost );
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Initial resize of a side image with no width predefined now gives correct percentage values.

---

### Additional information

Related issue ckeditor/ckeditor5-image#306.