### PR TITLE
Reposition visible toolbar when it is in a not visible stack of rotator.

### DIFF
--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -222,7 +222,8 @@ export default class WidgetToolbarRepository extends Plugin {
 			this.listenTo( this._balloon, 'change:visibleView', () => {
 				for ( const definition of this._toolbarDefinitions.values() ) {
 					if ( this._isToolbarVisible( definition ) ) {
-						this._updateToolbarsVisibility( definition );
+						const relatedElement = definition.getRelatedElement( this.editor.editing.view.document.selection );
+						repositionContextualBalloon( this.editor, relatedElement );
 					}
 				}
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Reposition visible toolbar when it is in a not visible stack of rotator. Closes ckeditor/ckeditor5#1957.

---

### Additional information

* The previous fix was causing problems in some edge cases - ie when toolbar was removed on focus lost and the whole logic was re-applied twice instead of just repositioning the toolbar. See https://github.com/ckeditor/ckeditor5/issues/1957.
