### PR TITLE
Fixed image resize flashing unexpected size

### DIFF
--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -135,22 +135,27 @@ export default class WidgetResize extends Plugin {
 	 */
 	attachTo( options ) {
 		const resizer = new Resizer( options );
-		const widgetToolbarRepository = this.editor.plugins.get( 'WidgetToolbarRepository' );
+		const plugins = this.editor.plugins;
 
 		resizer.attach();
 
-		// Hiding widget toolbar to improve the performance (https://github.com/ckeditor/ckeditor5-widget/pull/112#issuecomment-564528765).
-		resizer.on( 'begin', () => {
-			widgetToolbarRepository.forceDisabled( 'resize' );
-		} );
+		if ( plugins.has( 'WidgetToolbarRepository' ) ) {
+			// Hiding widget toolbar to improve the performance
+			// (https://github.com/ckeditor/ckeditor5-widget/pull/112#issuecomment-564528765).
+			const widgetToolbarRepository = plugins.get( 'WidgetToolbarRepository' );
 
-		resizer.on( 'cancel', () => {
-			widgetToolbarRepository.clearForceDisabled( 'resize' );
-		} );
+			resizer.on( 'begin', () => {
+				widgetToolbarRepository.forceDisabled( 'resize' );
+			} );
 
-		resizer.on( 'commit', () => {
-			widgetToolbarRepository.clearForceDisabled( 'resize' );
-		} );
+			resizer.on( 'cancel', () => {
+				widgetToolbarRepository.clearForceDisabled( 'resize' );
+			} );
+
+			resizer.on( 'commit', () => {
+				widgetToolbarRepository.clearForceDisabled( 'resize' );
+			} );
+		}
 
 		this._resizers.set( options.viewElement, resizer );
 

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -135,8 +135,22 @@ export default class WidgetResize extends Plugin {
 	 */
 	attachTo( options ) {
 		const resizer = new Resizer( options );
+		const widgetToolbarRepository = this.editor.plugins.get( 'WidgetToolbarRepository' );
 
 		resizer.attach();
+
+		// Hiding widget toolbar to improve the performance (https://github.com/ckeditor/ckeditor5-widget/pull/112#issuecomment-564528765).
+		resizer.on( 'begin', () => {
+			widgetToolbarRepository.forceDisabled( 'resize' );
+		} );
+
+		resizer.on( 'cancel', () => {
+			widgetToolbarRepository.clearForceDisabled( 'resize' );
+		} );
+
+		resizer.on( 'commit', () => {
+			widgetToolbarRepository.clearForceDisabled( 'resize' );
+		} );
 
 		this._resizers.set( options.viewElement, resizer );
 

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -107,7 +107,6 @@ export default class WidgetResize extends Plugin {
 		};
 
 		const redrawFocusedResizerThrottled = throttle( redrawFocusedResizer, 200 ); // 5fps
-		// const redrawFocusedResizerThrottled = throttle( redrawFocusedResizer, 200 ); // 5fps
 
 		// Redraws occurring upon a change of visible resizer must not be throttled, as it is crucial for the initial
 		// render. Without it the resizer frame would be misaligned with resizing host for a fraction of second.

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -86,7 +86,7 @@ export default class WidgetResize extends Plugin {
 
 		this._observer.listenTo( domDocument, 'mousemove', ( event, domEventData ) => {
 			if ( this._activeResizer ) {
-				this._activeResizer.updateSize( domEventData );
+				this._activeResizer.updateSize( domEventData, this.editor );
 			}
 		} );
 
@@ -100,11 +100,14 @@ export default class WidgetResize extends Plugin {
 
 		const redrawFocusedResizer = () => {
 			if ( this._visibleResizer ) {
-				this._visibleResizer.redraw();
+				this.editor.editing.view.change( writer => {
+					this._visibleResizer.redraw( null, writer );
+				} );
 			}
 		};
 
 		const redrawFocusedResizerThrottled = throttle( redrawFocusedResizer, 200 ); // 5fps
+		// const redrawFocusedResizerThrottled = throttle( redrawFocusedResizer, 200 ); // 5fps
 
 		// Redraws occurring upon a change of visible resizer must not be throttled, as it is crucial for the initial
 		// render. Without it the resizer frame would be misaligned with resizing host for a fraction of second.

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -100,9 +100,7 @@ export default class WidgetResize extends Plugin {
 
 		const redrawFocusedResizer = () => {
 			if ( this._visibleResizer ) {
-				this.editor.editing.view.change( writer => {
-					this._visibleResizer.redraw( null, writer );
-				} );
+				this._visibleResizer.redraw( null );
 			}
 		};
 
@@ -178,6 +176,12 @@ mix( WidgetResize, ObservableMixin );
  * Interface describing a resizer. It allows to specify the resizing host, custom logic for calculating aspect ratio, etc.
  *
  * @interface ResizerOptions
+ */
+
+/**
+ * Editor instance associated with the resizer.
+ *
+ * @member {module:core/editor/editor~Editor} module:widget/widgetresize~ResizerOptions#editor
  */
 
 /**

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -146,15 +146,15 @@ export default class WidgetResize extends Plugin {
 
 			resizer.on( 'begin', () => {
 				widgetToolbarRepository.forceDisabled( 'resize' );
-			} );
+			}, { priority: 'lowest' } );
 
 			resizer.on( 'cancel', () => {
 				widgetToolbarRepository.clearForceDisabled( 'resize' );
-			} );
+			}, { priority: 'highest' } );
 
 			resizer.on( 'commit', () => {
 				widgetToolbarRepository.clearForceDisabled( 'resize' );
-			} );
+			}, { priority: 'highest' } );
 		}
 
 		this._resizers.set( options.viewElement, resizer );

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -193,10 +193,6 @@ mix( WidgetResize, ObservableMixin );
  */
 
 /**
- * @member {module:engine/view/downcastwriter~DowncastWriter} module:widget/widgetresize~ResizerOptions#downcastWriter
- */
-
-/**
  * A callback to be executed once the resizing process is done.
  *
  * It receives a `Number` (`newValue`) as a parameter.
@@ -206,9 +202,9 @@ mix( WidgetResize, ObservableMixin );
  *
  * ```js
  * {
+ *	editor,
  *	modelElement: data.item,
  *	viewElement: widget,
- *	downcastWriter: conversionApi.writer,
  *
  *	onCommit( newValue ) {
  *		editor.execute( 'imageResize', { width: newValue } );

--- a/src/widgetresize.js
+++ b/src/widgetresize.js
@@ -86,7 +86,7 @@ export default class WidgetResize extends Plugin {
 
 		this._observer.listenTo( domDocument, 'mousemove', ( event, domEventData ) => {
 			if ( this._activeResizer ) {
-				this._activeResizer.updateSize( domEventData, this.editor );
+				this._activeResizer.updateSize( domEventData );
 			}
 		} );
 
@@ -100,7 +100,7 @@ export default class WidgetResize extends Plugin {
 
 		const redrawFocusedResizer = () => {
 			if ( this._visibleResizer ) {
-				this._visibleResizer.redraw( null );
+				this._visibleResizer.redraw();
 			}
 		};
 

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -138,16 +138,34 @@ export default class Resizer {
 	 * @param {Event} domEventData
 	 */
 	updateSize( domEventData, editor ) {
+		const newSize = this._proposeNewSize( domEventData );
+
+		// editor.editing.view.change( writer => {
+		// 	const domResizeHost = this._getResizeHost();
+		// 	const unit = this._options.unit;
+
+		// 	const newWidth = ( unit === '%' ? newSize.widthPercents : newSize.width ) + this._options.unit;
+
+		// 	newSize.width = parseInt( newWidth );
+		// 	newSize.height = 20;
+		// 	newSize.handleHostWidth = parseInt( newWidth );
+		// 	newSize.handleHostHeight = 20;
+
+		// 	writer.setStyle( 'width', newWidth, this._options.viewElement );
+
+		// 	this.state.update( newSize );
+		// } );
+
 		editor.editing.view.change( writer => {
-			const domHandleHost = this._getHandleHost();
-			const domResizeHost = this._getResizeHost();
 			const unit = this._options.unit;
-			const newSize = this._proposeNewSize( domEventData );
 
 			const newWidth = ( unit === '%' ? newSize.widthPercents : newSize.width ) + this._options.unit;
 
-			domResizeHost.style.width = newWidth;
 			writer.setStyle( 'width', newWidth, this._options.viewElement );
+		} );
+
+		editor.editing.view.change( writer => {
+			const domHandleHost = this._getHandleHost();
 
 			const domHandleHostRect = new Rect( domHandleHost );
 

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -164,6 +164,9 @@ export default class Resizer {
 			writer.setStyle( 'width', newWidth, this._options.viewElement );
 		} );
 
+		// Get an actual image width, and:
+		// * reflect this size to the resize wrapper
+		// * apply this **real** size to the state
 		editor.editing.view.change( writer => {
 			const domHandleHost = this._getHandleHost();
 
@@ -177,6 +180,8 @@ export default class Resizer {
 
 			newSize.width = Math.round( domResizeHostRect.width );
 			newSize.height = Math.round( domResizeHostRect.height );
+
+			// writer.setStyle( 'width', domHandleHostRect.width + 'px', this._options.viewElement );
 
 			this.redraw( domHandleHostRect, writer );
 

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -81,7 +81,8 @@ export default class Resizer {
 		this.decorate( 'updateSize' );
 
 		this.on( 'commit', event => {
-			// State might not be initialized yet. In this case, prevent further handling and make sure that the resizer is cleaned up (#5195).
+			// State might not be initialized yet. In this case, prevent further handling and make sure that the resizer is
+			// cleaned up (#5195).
 			if ( !this.state.proposedWidth ) {
 				this._cleanup();
 				event.stop();
@@ -95,32 +96,34 @@ export default class Resizer {
 	attach() {
 		const that = this;
 		const widgetElement = this._options.viewElement;
-		const writer = this._options.downcastWriter;
+		const editingView = this._options.editor.editing.view;
 
-		const viewResizerWrapper = writer.createUIElement( 'div', {
-			class: 'ck ck-reset_all ck-widget__resizer'
-		}, function( domDocument ) {
-			const domElement = this.toDomElement( domDocument );
+		editingView.change( writer => {
+			const viewResizerWrapper = writer.createUIElement( 'div', {
+				class: 'ck ck-reset_all ck-widget__resizer'
+			}, function( domDocument ) {
+				const domElement = this.toDomElement( domDocument );
 
-			that._appendHandles( domElement );
-			that._appendSizeUI( domElement );
+				that._appendHandles( domElement );
+				that._appendSizeUI( domElement );
 
-			that._domResizerWrapper = domElement;
+				that._domResizerWrapper = domElement;
 
-			that.on( 'change:isEnabled', ( evt, propName, newValue ) => {
-				domElement.style.display = newValue ? '' : 'none';
+				that.on( 'change:isEnabled', ( evt, propName, newValue ) => {
+					domElement.style.display = newValue ? '' : 'none';
+				} );
+
+				domElement.style.display = that.isEnabled ? '' : 'none';
+
+				return domElement;
 			} );
 
-			domElement.style.display = that.isEnabled ? '' : 'none';
+			// Append the resizer wrapper to the widget's wrapper.
+			writer.insert( writer.createPositionAt( widgetElement, 'end' ), viewResizerWrapper );
+			writer.addClass( 'ck-widget_with-resizer', widgetElement );
 
-			return domElement;
+			this._viewResizerWrapper = viewResizerWrapper;
 		} );
-
-		// Append the resizer wrapper to the widget's wrapper.
-		writer.insert( writer.createPositionAt( widgetElement, 'end' ), viewResizerWrapper );
-		writer.addClass( 'ck-widget_with-resizer', widgetElement );
-
-		this._viewResizerWrapper = viewResizerWrapper;
 	}
 
 	/**

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -81,7 +81,7 @@ export default class Resizer {
 		this.decorate( 'updateSize' );
 
 		this.on( 'commit', event => {
-			// State might not be initialized.In this case prevent further handling and make sure that resizer is cleaned up (#5195).
+			// State might not be initialized yet. In this case, prevent further handling and make sure that the resizer is cleaned up (#5195).
 			if ( !this.state.proposedWidth ) {
 				this._cleanup();
 				event.stop();

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -157,10 +157,13 @@ export default class Resizer {
 	 * @fires commit
 	 */
 	commit() {
-		const unit = this._options.unit;
-		const newValue = ( unit === '%' ? this.state.proposedWidthPercents : this.state.proposedWidth ) + this._options.unit;
+		if ( this.state.proposedWidth ) {
+			// State might not be initialized (#5195).
+			const unit = this._options.unit;
+			const newValue = ( unit === '%' ? this.state.proposedWidthPercents : this.state.proposedWidth ) + this._options.unit;
 
-		this._options.onCommit( newValue );
+			this._options.onCommit( newValue );
+		}
 
 		this._cleanup();
 	}

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -140,26 +140,9 @@ export default class Resizer {
 	updateSize( domEventData, editor ) {
 		const newSize = this._proposeNewSize( domEventData );
 
-		// editor.editing.view.change( writer => {
-		// 	const domResizeHost = this._getResizeHost();
-		// 	const unit = this._options.unit;
-
-		// 	const newWidth = ( unit === '%' ? newSize.widthPercents : newSize.width ) + this._options.unit;
-
-		// 	newSize.width = parseInt( newWidth );
-		// 	newSize.height = 20;
-		// 	newSize.handleHostWidth = parseInt( newWidth );
-		// 	newSize.handleHostHeight = 20;
-
-		// 	writer.setStyle( 'width', newWidth, this._options.viewElement );
-
-		// 	this.state.update( newSize );
-		// } );
-
 		editor.editing.view.change( writer => {
 			const unit = this._options.unit;
-
-			const newWidth = ( unit === '%' ? newSize.widthPercents : newSize.width ) + this._options.unit;
+			const newWidth = ( unit === '%' ? newSize.widthPercents : newSize.width ) + unit;
 
 			writer.setStyle( 'width', newWidth, this._options.viewElement );
 		} );
@@ -180,8 +163,6 @@ export default class Resizer {
 
 			newSize.width = Math.round( domResizeHostRect.width );
 			newSize.height = Math.round( domResizeHostRect.height );
-
-			// writer.setStyle( 'width', domHandleHostRect.width + 'px', this._options.viewElement );
 
 			this.redraw( domHandleHostRect, writer );
 
@@ -225,7 +206,6 @@ export default class Resizer {
 	 * @param {module:utils/dom/rect~Rect} [handleHostRect] Handle host rectangle might be given to improve performance.
 	 */
 	redraw( handleHostRect, writer ) {
-		// TODO review this
 		const domWrapper = this._domResizerWrapper;
 
 		if ( existsInDom( domWrapper ) ) {

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -81,7 +81,7 @@ export default class Resizer {
 		this.decorate( 'updateSize' );
 
 		this.on( 'commit', event => {
-			// State might not be initialized (#5195).
+			// State might not be initialized.In this case prevent further handling and make sure that resizer is cleaned up (#5195).
 			if ( !this.state.proposedWidth ) {
 				this._cleanup();
 				event.stop();

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -71,6 +71,14 @@ export default class Resizer {
 		this.decorate( 'cancel' );
 		this.decorate( 'commit' );
 		this.decorate( 'updateSize' );
+
+		this.on( 'commit', event => {
+			// State might not be initialized (#5195).
+			if ( !this.state.proposedWidth ) {
+				this._cleanup();
+				event.stop();
+			}
+		}, { priority: 'high' } );
 	}
 
 	/**
@@ -157,13 +165,10 @@ export default class Resizer {
 	 * @fires commit
 	 */
 	commit() {
-		if ( this.state.proposedWidth ) {
-			// State might not be initialized (#5195).
-			const unit = this._options.unit;
-			const newValue = ( unit === '%' ? this.state.proposedWidthPercents : this.state.proposedWidth ) + this._options.unit;
+		const unit = this._options.unit;
+		const newValue = ( unit === '%' ? this.state.proposedWidthPercents : this.state.proposedWidth ) + this._options.unit;
 
-			this._options.onCommit( newValue );
-		}
+		this._options.onCommit( newValue );
 
 		this._cleanup();
 	}

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -63,12 +63,12 @@ export default class Resizer {
 		this._domResizerWrapper = null;
 
 		/**
-		 * View to a wrapper of an element controlled by this resizer.
+		 * A wrapper that is controlled by the resizer. This is usually a widget element.
 		 *
 		 * @private
 		 * @type {module:engine/view/element~Element|null}
 		 */
-		this._resizerWrapperView = null;
+		this._viewResizerWrapper = null;
 
 		/**
 		 * @observable
@@ -120,7 +120,7 @@ export default class Resizer {
 		writer.insert( writer.createPositionAt( widgetElement, 'end' ), viewResizerWrapper );
 		writer.addClass( 'ck-widget_with-resizer', widgetElement );
 
-		this._resizerWrapperView = viewResizerWrapper;
+		this._viewResizerWrapper = viewResizerWrapper;
 	}
 
 	/**
@@ -221,8 +221,8 @@ export default class Resizer {
 				const handleHost = this._getHandleHost();
 				const clientRect = handleHostRect || new Rect( handleHost );
 
-				writer.setStyle( 'width', clientRect.width + 'px', this._resizerWrapperView );
-				writer.setStyle( 'height', clientRect.height + 'px', this._resizerWrapperView );
+				writer.setStyle( 'width', clientRect.width + 'px', this._viewResizerWrapper );
+				writer.setStyle( 'height', clientRect.height + 'px', this._viewResizerWrapper );
 
 				const offsets = {
 					left: handleHost.offsetLeft,
@@ -236,11 +236,11 @@ export default class Resizer {
 				// or simply another editable. By doing that the border and resizers are shown
 				// only around the resize host.
 				if ( !widgetWrapper.isSameNode( handleHost ) ) {
-					writer.setStyle( 'left', offsets.left + 'px', this._resizerWrapperView );
-					writer.setStyle( 'top', offsets.top + 'px', this._resizerWrapperView );
+					writer.setStyle( 'left', offsets.left + 'px', this._viewResizerWrapper );
+					writer.setStyle( 'top', offsets.top + 'px', this._viewResizerWrapper );
 
-					writer.setStyle( 'height', offsets.height + 'px', this._resizerWrapperView );
-					writer.setStyle( 'width', offsets.width + 'px', this._resizerWrapperView );
+					writer.setStyle( 'height', offsets.height + 'px', this._viewResizerWrapper );
+					writer.setStyle( 'width', offsets.width + 'px', this._viewResizerWrapper );
 				}
 			} );
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed image resize behavior upon short clicking a handle without dragging. Image will no longer became full width, nor will it briefly flash an unexpected size. Closes ckeditor/ckeditor5#5189 and closes ckeditor/ckeditor5#5195.

MINOR BREAKING CHANGE: Resizer options object now also takes an editor instance.

---

### Additional information

* **note** Since [ResizerOptions](https://ckeditor.com/docs/ckeditor5/latest/api/module_widget_widgetresize-ResizerOptions.html) now holds editor reference, it is no longer needed to keep [`downcastWriter`](https://ckeditor.com/docs/ckeditor5/latest/api/module_widget_widgetresize-ResizerOptions.html#member-downcastWriter) so I'd also like to remove this property. I find it to be a minor breaking change, please confirm that.

Short overview of the problems:

* flickering image at the first render (#5189)
	The issue is caused by the fact that we played a little against the UI with the initial implementation.

	The resizer was applying the new `width` styles **directly** to the `img` DOM element, skipping view abstraction. What happened there was that imageresize plugin added a `img.image_resized` class to the `img`'s **view**, which gives it a `100%` width. Since the view knew nothing about the width attribute, it did not add it while re-rendering `img`. Thus was getting full width for a brief moment, until the DOM img was modified once again directly.

	Now implementation works with view, that required me to pass `editor` instance to the resizer so I can request for a view writer.

* committing full image width, when end user only clicks the handle (but does not move the cursor) (#5195)
	The problem is caused by the fact that `commit()` accesses an uninitialized state. And this occurs when user clicks the resize and releases the cursor but does not trigger `mousemove` event, thus the state is never initialized.

	It could be worked around in the imageresize plugin itself (just checking the state here), but the fix should be in the core and prevent commit from being issued.

Subprs:
* ckeditor/ckeditor5-image/pull/334