### PR TITLE
Introduced disabling API for the WidgetToolbarRepository class

### DIFF
--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -132,6 +132,10 @@ export default class WidgetToolbarRepository extends Plugin {
 		 */
 		this._balloon = this.editor.plugins.get( 'ContextualBalloon' );
 
+		this.on( 'change:isEnabled', () => {
+			this._updateToolbarsVisibility();
+		} );
+
 		this.listenTo( editor.ui, 'update', () => {
 			this._updateToolbarsVisibility();
 		} );
@@ -222,7 +226,11 @@ export default class WidgetToolbarRepository extends Plugin {
 		for ( const definition of this._toolbarDefinitions.values() ) {
 			const relatedElement = definition.getRelatedElement( this.editor.editing.view.document.selection );
 
-			if ( !this.editor.ui.focusTracker.isFocused ) {
+			if ( !this.isEnabled ) {
+				if ( this._isToolbarInBalloon( definition ) ) {
+					this._hideToolbar( definition );
+				}
+			} else if ( !this.editor.ui.focusTracker.isFocused ) {
 				if ( this._isToolbarVisible( definition ) ) {
 					this._hideToolbar( definition );
 				}

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -219,7 +219,7 @@ export default class WidgetToolbarRepository extends Plugin {
 	}
 
 	/**
-	 * Clears forced disable previously set through {@link #clearForceDisabled}. See {@link #clearForceDisabled}.
+	 * Clears forced disable previously set through {@link #forceDisabled}. See {@link #forceDisabled}.
 	 *
 	 * @param {String} id Unique identifier, equal to the one passed in {@link #forceDisabled} call.
 	 */

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -245,16 +245,12 @@ export default class WidgetToolbarRepository extends Plugin {
 		for ( const definition of this._toolbarDefinitions.values() ) {
 			const relatedElement = definition.getRelatedElement( this.editor.editing.view.document.selection );
 
-			if ( !this.isEnabled ) {
+			if ( !this.isEnabled || !relatedElement ) {
 				if ( this._isToolbarInBalloon( definition ) ) {
 					this._hideToolbar( definition );
 				}
 			} else if ( !this.editor.ui.focusTracker.isFocused ) {
 				if ( this._isToolbarVisible( definition ) ) {
-					this._hideToolbar( definition );
-				}
-			} else if ( !relatedElement ) {
-				if ( this._isToolbarInBalloon( definition ) ) {
 					this._hideToolbar( definition );
 				}
 			} else {

--- a/tests/widgettoolbarrepository.js
+++ b/tests/widgettoolbarrepository.js
@@ -141,6 +141,32 @@ describe( 'WidgetToolbarRepository', () => {
 			expect( balloon.visibleView ).to.equal( fakeWidgetToolbarView );
 		} );
 
+		it( 'toolbar should be hidden when the plugin gets disabled', () => {
+			widgetToolbarRepository.register( 'fake', {
+				items: editor.config.get( 'fake.toolbar' ),
+				getRelatedElement: getSelectedFakeWidget
+			} );
+
+			setData( model, '<paragraph>foo</paragraph>[<fake-widget></fake-widget>]' );
+
+			widgetToolbarRepository.isEnabled = false;
+
+			expect( balloon.visibleView ).to.be.null;
+		} );
+
+		it( 'toolbar should be hidden when the plugin was disabled prior changing selection', () => {
+			widgetToolbarRepository.register( 'fake', {
+				items: editor.config.get( 'fake.toolbar' ),
+				getRelatedElement: getSelectedFakeWidget
+			} );
+
+			widgetToolbarRepository.isEnabled = false;
+
+			setData( model, '<paragraph>foo</paragraph>[<fake-widget></fake-widget>]' );
+
+			expect( balloon.visibleView ).to.be.null;
+		} );
+
 		it( 'toolbar should be hidden when the `getRelatedElement` callback returns null', () => {
 			widgetToolbarRepository.register( 'fake', {
 				items: editor.config.get( 'fake.toolbar' ),
@@ -511,7 +537,7 @@ describe( 'WidgetToolbarRepository - integration with the BalloonToolbar', () =>
 		expect( balloon.visibleView ).to.equal( balloonToolbar.toolbarView );
 	} );
 
-	describe.only( 'disableable', () => {
+	describe( 'disableable', () => {
 		describe( 'isEnabled', () => {
 			it( 'is enabled by default', () => {
 				expect( widgetToolbarRepository.isEnabled ).to.be.true;

--- a/tests/widgettoolbarrepository.js
+++ b/tests/widgettoolbarrepository.js
@@ -510,6 +510,82 @@ describe( 'WidgetToolbarRepository - integration with the BalloonToolbar', () =>
 
 		expect( balloon.visibleView ).to.equal( balloonToolbar.toolbarView );
 	} );
+
+	describe.only( 'disableable', () => {
+		describe( 'isEnabled', () => {
+			it( 'is enabled by default', () => {
+				expect( widgetToolbarRepository.isEnabled ).to.be.true;
+			} );
+
+			it( 'fires change event', () => {
+				const spy = sinon.spy();
+
+				widgetToolbarRepository.on( 'change:isEnabled', spy );
+
+				widgetToolbarRepository.isEnabled = false;
+
+				expect( spy.calledOnce ).to.be.true;
+			} );
+		} );
+
+		describe( 'forceDisabled() / clearForceDisabled()', () => {
+			it( 'forceDisabled() should disable the plugin', () => {
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.isEnabled = true;
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.false;
+			} );
+
+			it( 'clearForceDisabled() should enable the plugin', () => {
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.clearForceDisabled( 'foo' );
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.true;
+			} );
+
+			it( 'clearForceDisabled() used with wrong identifier should not enable the plugin', () => {
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.clearForceDisabled( 'bar' );
+				widgetToolbarRepository.isEnabled = true;
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.false;
+			} );
+
+			it( 'using forceDisabled() twice with the same identifier should not have any effect', () => {
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.clearForceDisabled( 'foo' );
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.true;
+			} );
+
+			it( 'plugin is enabled only after all disables were cleared', () => {
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.forceDisabled( 'bar' );
+				widgetToolbarRepository.clearForceDisabled( 'foo' );
+				widgetToolbarRepository.isEnabled = true;
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.false;
+
+				widgetToolbarRepository.clearForceDisabled( 'bar' );
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.true;
+			} );
+
+			it( 'plugin should remain disabled if isEnabled has a callback disabling it', () => {
+				widgetToolbarRepository.on( 'set:isEnabled', evt => {
+					evt.return = false;
+					evt.stop();
+				} );
+
+				widgetToolbarRepository.forceDisabled( 'foo' );
+				widgetToolbarRepository.clearForceDisabled( 'foo' );
+				widgetToolbarRepository.isEnabled = true;
+
+				expect( widgetToolbarRepository.isEnabled ).to.be.false;
+			} );
+		} );
+	} );
 } );
 
 function getSelectedFakeWidget( selection ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced API to disable the [`WidgetToolbarRepository`](https://ckeditor.com/docs/ckeditor5/16.0.0/api/module_widget_widgettoolbarrepository-WidgetToolbarRepository.html) plugin. Closes ckeditor/ckeditor5#5964.

---

### Additional information

Since this is already used in the `Command` class, there was an option to implement this as an interface and add a common mixin to avoid code duplication. However during an offline meeting we decided to go with easier option and just copy'n'paste it from the `Command` class.