### PR TITLE
Revert view element's original width after resize

### DIFF
--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -188,6 +188,10 @@ export default class Resizer {
 		const unit = this._options.unit;
 		const newValue = ( unit === '%' ? this.state.proposedWidthPercents : this.state.proposedWidth ) + this._options.unit;
 
+		this._options.editor.editing.view.change( writer => {
+			writer.setStyle( 'width', this.state.originalWidth + 'px', this._options.viewElement );
+		} );
+
 		this._options.onCommit( newValue );
 
 		this._cleanup();

--- a/src/widgetresize/resizer.js
+++ b/src/widgetresize/resizer.js
@@ -194,6 +194,10 @@ export default class Resizer {
 
 		this._options.onCommit( newValue );
 
+		const domHandleHost = this._getHandleHost();
+		const domHandleHostRect = new Rect( domHandleHost );
+		this.redraw( domHandleHostRect );
+
 		this._cleanup();
 	}
 


### PR DESCRIPTION
Fix: Revert view element's original width after resize and let the model handle it

Closes https://github.com/ckeditor/ckeditor5/issues/6060