### PR TITLE
i/5862: Remove forceDisabled and clearForceDisabled methods from WidgetToolbarRepository

### DIFF
--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -100,14 +100,6 @@ export default class WidgetToolbarRepository extends Plugin {
 		 */
 		this._balloon = this.editor.plugins.get( 'ContextualBalloon' );
 
-		/**
-		 * Holds identifiers for {@link #forceDisabled} mechanism.
-		 *
-		 * @type {Set.<String>}
-		 * @private
-		 */
-		this._disableStack = new Set();
-
 		this.on( 'change:isEnabled', () => {
 			this._updateToolbarsVisibility();
 		} );
@@ -169,67 +161,6 @@ export default class WidgetToolbarRepository extends Plugin {
 			getRelatedElement,
 			balloonClassName,
 		} );
-	}
-
-	/**
-	 * Forces the plugin to be disabled.
-	 *
-	 * Plugin may be disabled by multiple features or algorithms (at once). When disabling a plugin, unique id should be passed
-	 * (e.g. feature name). The same identifier should be used when {@link #clearForceDisabled enabling back} the plugin.
-	 * The plugin becomes enabled only after all features {@link #clearForceDisabled enabled it back}.
-	 *
-	 * Disabling and enabling a plugin:
-	 *
-	 *		const plugin = editor.plugins.get( 'WidgetToolbarRepository' );
-	 *
-	 *		plugin.isEnabled; // -> true
-	 *		plugin.forceDisabled( 'MyFeature' );
-	 *		plugin.isEnabled; // -> false
-	 *		plugin.clearForceDisabled( 'MyFeature' );
-	 *		plugin.isEnabled; // -> true
-	 *
-	 * Plugin disabled by multiple features:
-	 *
-	 *		plugin.forceDisabled( 'MyFeature' );
-	 *		plugin.forceDisabled( 'OtherFeature' );
-	 *		plugin.clearForceDisabled( 'MyFeature' );
-	 *		plugin.isEnabled; // -> false
-	 *		plugin.clearForceDisabled( 'OtherFeature' );
-	 *		plugin.isEnabled; // -> true
-	 *
-	 * Multiple disabling with the same identifier is redundant:
-	 *
-	 *		plugin.forceDisabled( 'MyFeature' );
-	 *		plugin.forceDisabled( 'MyFeature' );
-	 *		plugin.clearForceDisabled( 'MyFeature' );
-	 *		plugin.isEnabled; // -> true
-	 *
-	 * **Note:** some plugins or algorithms may have more complex logic when it comes to enabling or disabling certain plugins,
-	 * so the plugin might be still disabled after {@link #clearForceDisabled} was used.
-	 *
-	 * @param {String} id Unique identifier for disabling. Use the same id when {@link #clearForceDisabled enabling back} the plugin.
-	 */
-	forceDisabled( id ) {
-		this._disableStack.add( id );
-
-		if ( this._disableStack.size == 1 ) {
-			this.on( 'set:isEnabled', forceDisable, { priority: 'highest' } );
-			this.isEnabled = false;
-		}
-	}
-
-	/**
-	 * Clears forced disable previously set through {@link #forceDisabled}. See {@link #forceDisabled}.
-	 *
-	 * @param {String} id Unique identifier, equal to the one passed in {@link #forceDisabled} call.
-	 */
-	clearForceDisabled( id ) {
-		this._disableStack.delete( id );
-
-		if ( this._disableStack.size == 0 ) {
-			this.off( 'set:isEnabled', forceDisable );
-			this.isEnabled = true;
-		}
 	}
 
 	/**
@@ -383,9 +314,3 @@ function isWidgetSelected( selection ) {
  * there is no such element). The function accepts an instance of {@link module:engine/view/selection~Selection}.
  * @property {String} balloonClassName CSS class for the widget balloon when a toolbar is displayed.
  */
-
-// Helper function that forces command to be disabled.
-function forceDisable( evt ) {
-	evt.return = false;
-	evt.stop();
-}

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -71,6 +71,11 @@ export default class WidgetToolbarRepository extends Plugin {
 		}
 
 		/**
+		 * @observable
+		 */
+		this.set( 'isEnabled', true );
+
+		/**
 		 * A map of toolbar definitions.
 		 *
 		 * @protected

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -71,11 +71,6 @@ export default class WidgetToolbarRepository extends Plugin {
 		}
 
 		/**
-		 * @observable
-		 */
-		this.set( 'isEnabled', true );
-
-		/**
 		 * A map of toolbar definitions.
 		 *
 		 * @protected

--- a/src/widgettoolbarrepository.js
+++ b/src/widgettoolbarrepository.js
@@ -71,23 +71,6 @@ export default class WidgetToolbarRepository extends Plugin {
 		}
 
 		/**
-		 * Flag indicating whether a plugin is enabled or disabled.
-		 * A disabled plugin won't show any toolbar.
-		 *
-		 * Plugin can be simply disabled like that:
-		 *
-		 *		// Disable the plugin so that no toolbars are visible.
-		 *		editor.plugins.get( 'WidgetToolbarRepository' ).isEnabled = false;
-		 *
-		 * You can also use {@link #forceDisabled} method.
-		 *
-		 * @observable
-		 * @readonly
-		 * @member {Boolean} #isEnabled
-		 */
-		this.set( 'isEnabled', true );
-
-		/**
 		 * A map of toolbar definitions.
 		 *
 		 * @protected


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove forceDisabled and clearForceDisabled methods from WidgetToolbarRepository, because now it inherits them from the Plugin class. Closes ckeditor/ckeditor5#5862.

---
Depends on: https://github.com/ckeditor/ckeditor5-core/pull/208
Master PR: https://github.com/ckeditor/ckeditor5-typing/pull/222
